### PR TITLE
fix: kid display follow-ups — chore dedup, loading escape hatch, docs

### DIFF
--- a/beacon/src/App.tsx
+++ b/beacon/src/App.tsx
@@ -135,7 +135,21 @@ export function App() {
   // Kid Display (focus) mode — URL param wins, then device-local storage
   const [focusMemberId, setFocusMemberId] = useState<string | null>(() => getFocusMemberId());
   const focusMember = focusMemberId ? members.find((m) => m.id === focusMemberId) : undefined;
-  const focusInvalid = !!focusMemberId && members.length > 0 && !focusMember;
+
+  // Escape hatch: if a display is assigned to a member but the family list
+  // stays empty (fresh device, stale assignment), stop waiting after 10s and
+  // fall through to the invalid-member banner instead of loading forever.
+  const [focusLoadTimedOut, setFocusLoadTimedOut] = useState(false);
+  useEffect(() => {
+    if (!focusMemberId || members.length > 0) {
+      setFocusLoadTimedOut(false);
+      return;
+    }
+    const t = setTimeout(() => setFocusLoadTimedOut(true), 10_000);
+    return () => clearTimeout(t);
+  }, [focusMemberId, members.length]);
+
+  const focusInvalid = !!focusMemberId && !focusMember && (members.length > 0 || focusLoadTimedOut);
 
   const handleExitFocus = useCallback(() => {
     clearFocusMode();
@@ -439,7 +453,7 @@ export function App() {
 
   // Focus member requested but members not loaded yet (fresh device cache):
   // hold on a lightweight loading screen instead of flashing the full app.
-  if (focusMemberId && members.length === 0) {
+  if (focusMemberId && members.length === 0 && !focusLoadTimedOut) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', background: 'var(--bg-primary)' }}>
         <div style={{ textAlign: 'center', color: 'var(--text-muted)' }}>Loading...</div>

--- a/beacon/src/api/family.ts
+++ b/beacon/src/api/family.ts
@@ -131,6 +131,14 @@ export class FamilyStore {
 
   async completeChore(choreId: string, memberId: string, verifiedBy?: string): Promise<ChoreCompletion> {
     const completions = await this.getCompletions();
+    const today = new Date().toISOString().slice(0, 10);
+    const existing = completions.find(
+      (c) =>
+        c.chore_id === choreId &&
+        c.member_id === memberId &&
+        c.completed_at.slice(0, 10) === today
+    );
+    if (existing) return existing;
     const completion: ChoreCompletion = {
       chore_id: choreId,
       member_id: memberId,

--- a/docs-site/src/content/docs/features/kid-display.mdx
+++ b/docs-site/src/content/docs/features/kid-display.mdx
@@ -1,0 +1,116 @@
+---
+title: "Kid Display Mode"
+description: "Lock a wall-mounted screen or tablet to a single family member's routines and chores — ideal for kids' rooms and kiosk setups."
+order: 11
+---
+
+# Kid Display Mode
+
+Kid Display Mode locks a screen or tablet to a single family member, showing only their routine for the current time of day and their assigned chores. It is built for wall-mounted tablets in kids' rooms, where you want a focused, distraction-free view instead of the full Beacon dashboard.
+
+---
+
+## What the display shows
+
+When a device is in Kid Display Mode, it shows:
+
+- The family member's **avatar and name** with a greeting
+- A **live clock and date**
+- The **routine for the current time of day** — morning (before 12:00), afternoon (12:00–17:00), or evening (after 17:00)
+- The member's **assigned chores**, including their reward values
+
+Tap targets are large, designed for kids to use directly. Tapping a task or chore checks it off; tapping it again undoes it.
+
+If no routine exists for the current time period, the next upcoming routine is shown read-only as a preview, labeled things like "Tonight" or "Tomorrow morning".
+
+When every routine task and chore for the day is complete, the display shows a celebration screen: "All done — great job!"
+
+---
+
+## Entering Kid Display Mode
+
+There are two ways to put a device into Kid Display Mode.
+
+### URL parameter
+
+Append `?display=<memberId>` to Beacon's URL. This is bookmarkable and is the best option for kiosk browsers (like Fully Kiosk Browser) or Home Assistant wallpanel apps, since it survives reboots and takes precedence over any device-level setting.
+
+### Settings > Display
+
+1. Open **Settings > Display**
+2. Under **Kid Display**, choose a family member
+3. Choose how to apply it:
+   - **Use on This Device** — persists the assignment for this browser/device via localStorage
+   - **Copy URL** — copies the bookmarkable `?display=<memberId>` URL for kiosk setups
+
+> **Note**: If both are present, the URL parameter takes precedence over the device-level (localStorage) assignment.
+
+---
+
+## Setting up routines
+
+Routines are created per family member, not from the Kid Display screen itself:
+
+1. Open **Settings > Family Members**
+2. Click the **checklist icon** on the member's card
+3. Create a routine with:
+   - A **name**
+   - A **time of day** — morning, afternoon, or evening
+   - An **ordered list of tasks** (add, remove, and reorder as needed)
+
+A family member can have multiple routines, including more than one for the same time-of-day period. Only the first routine for the current period is shown on the display.
+
+---
+
+## Completing tasks and chores
+
+Routine tasks and chores both use the same big tap-to-complete interaction:
+
+- Tap an incomplete item to check it off
+- Tap a completed item again to undo it
+
+Routine task completions **reset every day** automatically. Chore completions feed into the same streaks and leaderboard tracking used everywhere else in Beacon, recorded under that family member's ID — see [Chores](/docs/features/chores/) for how streaks and the leaderboard work.
+
+---
+
+## Exiting Kid Display Mode
+
+Kid Display Mode is intentionally hard to exit by accident:
+
+1. Tap the **clock** 5 times within 3 seconds
+2. Confirm the exit in the dialog that appears
+
+Exiting clears the device's Kid Display assignment and strips the `?display=` parameter from the URL, returning the device to the full Beacon app.
+
+---
+
+## Screen saver and notifications
+
+- The normal [Screen Saver](/docs/features/screensaver/) behavior (dim mode and the clock screensaver) still runs on kid displays according to your usual Display settings — this keeps burn-in protection active on always-on screens.
+- Kid displays do **not** fire event push notifications and do not prompt for notification permission. See [Notifications](/docs/features/notifications/) for how that works on the full dashboard.
+
+---
+
+## Using ingress URLs for kiosk setups
+
+If you copy a Kid Display URL while accessing Beacon through Home Assistant ingress, the kiosk device will need an authenticated HA session for that URL to keep working. For dedicated kiosk browsers, it's simpler to use a direct (non-ingress) Beacon URL instead of the ingress path.
+
+---
+
+## Troubleshooting
+
+### The display shows "member not found"
+
+This happens if the assigned family member was deleted, or the `memberId` in the URL is invalid. The full Beacon app loads with a dismissible banner. Re-assign the device to a valid member from **Settings > Display**, or update the bookmarked URL.
+
+### The wrong routine (or no routine) is showing
+
+Only the first routine matching the current time-of-day period (morning, afternoon, evening) is displayed. If a member has multiple routines in the same period, check their order in **Settings > Family Members** — the checklist icon on their card.
+
+### Chore completions aren't showing up on the leaderboard
+
+Chore completions from Kid Display Mode are recorded under the same member ID used everywhere else in Beacon, so they should appear on the [leaderboard](/docs/features/chores/) immediately. If they don't, verify the device is actually assigned to the expected member in **Settings > Display**.
+
+### The "day" seems to roll over at the wrong local time
+
+Completions are date-stamped in UTC, consistent with how chores are recorded elsewhere in Beacon. If your timezone is far from UTC, the day can roll over during your local evening rather than at midnight local time. This is a known limitation — routine and chore state for "today" is always based on the UTC date.

--- a/docs/superpowers/specs/2026-07-04-kid-display-mode-design.md
+++ b/docs/superpowers/specs/2026-07-04-kid-display-mode-design.md
@@ -130,9 +130,14 @@ Each member row in the existing family-member management UI gains a
 - Unknown/deleted focus member → banner + normal app (see §1).
 - Member deleted while a display is in focus mode → member resolution fails on
   next data refresh; FocusView exits to the normal app.
-- Offline/HA-down: `beacon-store` already reads server-first with localStorage
-  cache; the display keeps rendering cached data. Completions queue in
-  localStorage and push in the background (existing behavior).
+- Offline/HA-down: `beacon-store` reads server-first with a localStorage
+  cache; the display keeps rendering cached data. Writes go to localStorage
+  immediately and are pushed to the server as a fire-and-forget PUT — there
+  is no retry queue. If the server PUT fails, a later successful server read
+  overwrites the local cache and the offline completion is lost. Concurrent
+  writes from multiple displays are last-write-wins within the short
+  read-modify-write window (mitigated by server-first reads before each
+  mutation; worst case is one lost checkmark).
 
 ## 6. Verification
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,7 +135,21 @@ export function App() {
   // Kid Display (focus) mode — URL param wins, then device-local storage
   const [focusMemberId, setFocusMemberId] = useState<string | null>(() => getFocusMemberId());
   const focusMember = focusMemberId ? members.find((m) => m.id === focusMemberId) : undefined;
-  const focusInvalid = !!focusMemberId && members.length > 0 && !focusMember;
+
+  // Escape hatch: if a display is assigned to a member but the family list
+  // stays empty (fresh device, stale assignment), stop waiting after 10s and
+  // fall through to the invalid-member banner instead of loading forever.
+  const [focusLoadTimedOut, setFocusLoadTimedOut] = useState(false);
+  useEffect(() => {
+    if (!focusMemberId || members.length > 0) {
+      setFocusLoadTimedOut(false);
+      return;
+    }
+    const t = setTimeout(() => setFocusLoadTimedOut(true), 10_000);
+    return () => clearTimeout(t);
+  }, [focusMemberId, members.length]);
+
+  const focusInvalid = !!focusMemberId && !focusMember && (members.length > 0 || focusLoadTimedOut);
 
   const handleExitFocus = useCallback(() => {
     clearFocusMode();
@@ -439,7 +453,7 @@ export function App() {
 
   // Focus member requested but members not loaded yet (fresh device cache):
   // hold on a lightweight loading screen instead of flashing the full app.
-  if (focusMemberId && members.length === 0) {
+  if (focusMemberId && members.length === 0 && !focusLoadTimedOut) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', background: 'var(--bg-primary)' }}>
         <div style={{ textAlign: 'center', color: 'var(--text-muted)' }}>Loading...</div>

--- a/src/api/family.ts
+++ b/src/api/family.ts
@@ -131,6 +131,14 @@ export class FamilyStore {
 
   async completeChore(choreId: string, memberId: string, verifiedBy?: string): Promise<ChoreCompletion> {
     const completions = await this.getCompletions();
+    const today = new Date().toISOString().slice(0, 10);
+    const existing = completions.find(
+      (c) =>
+        c.chore_id === choreId &&
+        c.member_id === memberId &&
+        c.completed_at.slice(0, 10) === today
+    );
+    if (existing) return existing;
     const completion: ChoreCompletion = {
       chore_id: choreId,
       member_id: memberId,


### PR DESCRIPTION
Follow-ups deferred from the Kid Display Mode review (PR #2):

- **Same-day dedup in `completeChore`**: double-tapping a chore no longer creates duplicate completion records (double earnings / stuck-done state). Mirrors the guard `completeRoutineTask` already had.
- **Kid display loading escape hatch**: a device with a stale member assignment and an empty family list now falls through to the dismissible "member not found" banner after 10s instead of showing "Loading..." forever (which had no exit path).
- **Spec §5 corrected**: offline behavior now documents the fire-and-forget PUT (no retry queue) and last-write-wins concurrency accurately.
- **Docs-site page**: `features/kid-display.mdx` — setup (URL + per-device), routines, exit gesture, ingress caveat, UTC rollover note. Docs build verified.

Verified: `tsc && vite build` clean; browser smoke of the escape hatch (loading at t+0 → banner at t+11s).

Still deferred (needs own design pass): coordinated UTC→local date-stamp migration for chore + routine completions.