### PR TITLE
fix: bucket completions by local day, not UTC

### DIFF
--- a/beacon/src/api/date-keys.ts
+++ b/beacon/src/api/date-keys.ts
@@ -1,0 +1,24 @@
+/**
+ * The calendar day a timestamp belongs to, in the viewer's LOCAL time zone,
+ * formatted as "YYYY-MM-DD".
+ *
+ * Completions are stored as full UTC ISO timestamps (`new Date().toISOString()`).
+ * Bucketing them by local day — rather than the UTC date embedded in the string —
+ * makes "today" roll over at local midnight. Without this, an evening completion
+ * in a negative-UTC-offset zone (e.g. 7:45pm US Eastern) would land on the next
+ * UTC date and appear to reset hours early.
+ *
+ * Because the stored value is a full timestamp, this is a pure reinterpretation:
+ * no data migration is needed — existing records bucket correctly going forward.
+ *
+ * An empty or unparseable value returns "" (matching the prior `''.slice(0,10)`
+ * sentinel used for "never completed").
+ */
+export function localDayKey(value: string | number | Date = new Date()): string {
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/beacon/src/api/family.ts
+++ b/beacon/src/api/family.ts
@@ -7,6 +7,7 @@ import {
   RoutineTaskCompletion,
 } from '../types/family';
 import { loadData, loadDataSync, saveData } from './beacon-store';
+import { localDayKey } from './date-keys';
 
 const STORAGE_KEYS = {
   members: 'beacon_family_members',
@@ -114,29 +115,29 @@ export class FamilyStore {
   }
 
   async getCompletionsToday(): Promise<ChoreCompletion[]> {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const completions = await this.getCompletions();
     return completions.filter(
-      (c) => c.completed_at.slice(0, 10) === today
+      (c) => localDayKey(c.completed_at) === today
     );
   }
 
   async getCompletionsForPeriod(startDate: string, endDate: string): Promise<ChoreCompletion[]> {
     const completions = await this.getCompletions();
     return completions.filter((c) => {
-      const date = c.completed_at.slice(0, 10);
+      const date = localDayKey(c.completed_at);
       return date >= startDate && date <= endDate;
     });
   }
 
   async completeChore(choreId: string, memberId: string, verifiedBy?: string): Promise<ChoreCompletion> {
     const completions = await this.getCompletions();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const existing = completions.find(
       (c) =>
         c.chore_id === choreId &&
         c.member_id === memberId &&
-        c.completed_at.slice(0, 10) === today
+        localDayKey(c.completed_at) === today
     );
     if (existing) return existing;
     const completion: ChoreCompletion = {
@@ -156,12 +157,12 @@ export class FamilyStore {
 
   async uncompleteChore(choreId: string, memberId: string): Promise<boolean> {
     const completions = await this.getCompletions();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const index = completions.findIndex(
       (c) =>
         c.chore_id === choreId &&
         c.member_id === memberId &&
-        c.completed_at.slice(0, 10) === today
+        localDayKey(c.completed_at) === today
     );
     if (index === -1) return false;
     completions.splice(index, 1);
@@ -183,8 +184,8 @@ export class FamilyStore {
 
   private async updateStreakForMember(memberId: string): Promise<void> {
     const streaks = await this.getStreaks();
-    const today = new Date().toISOString().slice(0, 10);
-    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    const today = localDayKey();
+    const yesterday = localDayKey(Date.now() - 86400000);
 
     let streak = streaks.find((s) => s.member_id === memberId);
     if (!streak) {
@@ -192,7 +193,7 @@ export class FamilyStore {
       streaks.push(streak);
     }
 
-    const lastDate = streak.last_completed.slice(0, 10);
+    const lastDate = localDayKey(streak.last_completed);
 
     if (lastDate === today) {
       // Already counted today
@@ -254,20 +255,20 @@ export class FamilyStore {
   }
 
   async getRoutineTaskCompletionsToday(): Promise<RoutineTaskCompletion[]> {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const completions = await this.getRoutineTaskCompletions();
-    return completions.filter((c) => c.completed_at.slice(0, 10) === today);
+    return completions.filter((c) => localDayKey(c.completed_at) === today);
   }
 
   async completeRoutineTask(routineId: string, taskId: string, memberId: string): Promise<void> {
     const completions = await this.getRoutineTaskCompletions();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const exists = completions.some(
       (c) =>
         c.routine_id === routineId &&
         c.task_id === taskId &&
         c.member_id === memberId &&
-        c.completed_at.slice(0, 10) === today
+        localDayKey(c.completed_at) === today
     );
     if (exists) return;
     completions.push({
@@ -281,13 +282,13 @@ export class FamilyStore {
 
   async uncompleteRoutineTask(routineId: string, taskId: string, memberId: string): Promise<boolean> {
     const completions = await this.getRoutineTaskCompletions();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const index = completions.findIndex(
       (c) =>
         c.routine_id === routineId &&
         c.task_id === taskId &&
         c.member_id === memberId &&
-        c.completed_at.slice(0, 10) === today
+        localDayKey(c.completed_at) === today
     );
     if (index === -1) return false;
     completions.splice(index, 1);

--- a/beacon/src/components/Leaderboard.tsx
+++ b/beacon/src/components/Leaderboard.tsx
@@ -3,6 +3,7 @@ import { StreakBadge } from './StreakBadge';
 import { useChores } from '../hooks/useChores';
 import { useFamily } from '../hooks/useFamily';
 import { MemberEarnings } from '../types/family';
+import { localDayKey } from '../api/date-keys';
 
 interface LeaderboardProps {
   open: boolean;
@@ -19,14 +20,14 @@ function getWeekRange(): [string, string] {
   start.setHours(0, 0, 0, 0);
   const end = new Date(start);
   end.setDate(start.getDate() + 7);
-  return [start.toISOString().slice(0, 10), end.toISOString().slice(0, 10)];
+  return [localDayKey(start), localDayKey(end)];
 }
 
 function getMonthRange(): [string, string] {
   const now = new Date();
   const start = new Date(now.getFullYear(), now.getMonth(), 1);
   const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-  return [start.toISOString().slice(0, 10), end.toISOString().slice(0, 10)];
+  return [localDayKey(start), localDayKey(end)];
 }
 
 function formatCents(cents: number): string {

--- a/src/api/date-keys.ts
+++ b/src/api/date-keys.ts
@@ -1,0 +1,24 @@
+/**
+ * The calendar day a timestamp belongs to, in the viewer's LOCAL time zone,
+ * formatted as "YYYY-MM-DD".
+ *
+ * Completions are stored as full UTC ISO timestamps (`new Date().toISOString()`).
+ * Bucketing them by local day — rather than the UTC date embedded in the string —
+ * makes "today" roll over at local midnight. Without this, an evening completion
+ * in a negative-UTC-offset zone (e.g. 7:45pm US Eastern) would land on the next
+ * UTC date and appear to reset hours early.
+ *
+ * Because the stored value is a full timestamp, this is a pure reinterpretation:
+ * no data migration is needed — existing records bucket correctly going forward.
+ *
+ * An empty or unparseable value returns "" (matching the prior `''.slice(0,10)`
+ * sentinel used for "never completed").
+ */
+export function localDayKey(value: string | number | Date = new Date()): string {
+  const d = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/src/api/family.ts
+++ b/src/api/family.ts
@@ -7,6 +7,7 @@ import {
   RoutineTaskCompletion,
 } from '../types/family';
 import { loadData, loadDataSync, saveData } from './beacon-store';
+import { localDayKey } from './date-keys';
 
 const STORAGE_KEYS = {
   members: 'beacon_family_members',
@@ -114,29 +115,29 @@ export class FamilyStore {
   }
 
   async getCompletionsToday(): Promise<ChoreCompletion[]> {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const completions = await this.getCompletions();
     return completions.filter(
-      (c) => c.completed_at.slice(0, 10) === today
+      (c) => localDayKey(c.completed_at) === today
     );
   }
 
   async getCompletionsForPeriod(startDate: string, endDate: string): Promise<ChoreCompletion[]> {
     const completions = await this.getCompletions();
     return completions.filter((c) => {
-      const date = c.completed_at.slice(0, 10);
+      const date = localDayKey(c.completed_at);
       return date >= startDate && date <= endDate;
     });
   }
 
   async completeChore(choreId: string, memberId: string, verifiedBy?: string): Promise<ChoreCompletion> {
     const completions = await this.getCompletions();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const existing = completions.find(
       (c) =>
         c.chore_id === choreId &&
         c.member_id === memberId &&
-        c.completed_at.slice(0, 10) === today
+        localDayKey(c.completed_at) === today
     );
     if (existing) return existing;
     const completion: ChoreCompletion = {
@@ -156,12 +157,12 @@ export class FamilyStore {
 
   async uncompleteChore(choreId: string, memberId: string): Promise<boolean> {
     const completions = await this.getCompletions();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const index = completions.findIndex(
       (c) =>
         c.chore_id === choreId &&
         c.member_id === memberId &&
-        c.completed_at.slice(0, 10) === today
+        localDayKey(c.completed_at) === today
     );
     if (index === -1) return false;
     completions.splice(index, 1);
@@ -183,8 +184,8 @@ export class FamilyStore {
 
   private async updateStreakForMember(memberId: string): Promise<void> {
     const streaks = await this.getStreaks();
-    const today = new Date().toISOString().slice(0, 10);
-    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+    const today = localDayKey();
+    const yesterday = localDayKey(Date.now() - 86400000);
 
     let streak = streaks.find((s) => s.member_id === memberId);
     if (!streak) {
@@ -192,7 +193,7 @@ export class FamilyStore {
       streaks.push(streak);
     }
 
-    const lastDate = streak.last_completed.slice(0, 10);
+    const lastDate = localDayKey(streak.last_completed);
 
     if (lastDate === today) {
       // Already counted today
@@ -254,20 +255,20 @@ export class FamilyStore {
   }
 
   async getRoutineTaskCompletionsToday(): Promise<RoutineTaskCompletion[]> {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const completions = await this.getRoutineTaskCompletions();
-    return completions.filter((c) => c.completed_at.slice(0, 10) === today);
+    return completions.filter((c) => localDayKey(c.completed_at) === today);
   }
 
   async completeRoutineTask(routineId: string, taskId: string, memberId: string): Promise<void> {
     const completions = await this.getRoutineTaskCompletions();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const exists = completions.some(
       (c) =>
         c.routine_id === routineId &&
         c.task_id === taskId &&
         c.member_id === memberId &&
-        c.completed_at.slice(0, 10) === today
+        localDayKey(c.completed_at) === today
     );
     if (exists) return;
     completions.push({
@@ -281,13 +282,13 @@ export class FamilyStore {
 
   async uncompleteRoutineTask(routineId: string, taskId: string, memberId: string): Promise<boolean> {
     const completions = await this.getRoutineTaskCompletions();
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey();
     const index = completions.findIndex(
       (c) =>
         c.routine_id === routineId &&
         c.task_id === taskId &&
         c.member_id === memberId &&
-        c.completed_at.slice(0, 10) === today
+        localDayKey(c.completed_at) === today
     );
     if (index === -1) return false;
     completions.splice(index, 1);

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -3,6 +3,7 @@ import { StreakBadge } from './StreakBadge';
 import { useChores } from '../hooks/useChores';
 import { useFamily } from '../hooks/useFamily';
 import { MemberEarnings } from '../types/family';
+import { localDayKey } from '../api/date-keys';
 
 interface LeaderboardProps {
   open: boolean;
@@ -19,14 +20,14 @@ function getWeekRange(): [string, string] {
   start.setHours(0, 0, 0, 0);
   const end = new Date(start);
   end.setDate(start.getDate() + 7);
-  return [start.toISOString().slice(0, 10), end.toISOString().slice(0, 10)];
+  return [localDayKey(start), localDayKey(end)];
 }
 
 function getMonthRange(): [string, string] {
   const now = new Date();
   const start = new Date(now.getFullYear(), now.getMonth(), 1);
   const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-  return [start.toISOString().slice(0, 10), end.toISOString().slice(0, 10)];
+  return [localDayKey(start), localDayKey(end)];
 }
 
 function formatCents(cents: number): string {


### PR DESCRIPTION
Fixes the last deferred follow-up from Kid Display Mode (PR #2/#3 review).

## Problem

Completions store a full UTC ISO timestamp in `completed_at`, but were bucketed into days by the **UTC date embedded in the string** (`.toISOString().slice(0, 10)`). In negative-UTC-offset time zones, an evening completion crosses UTC midnight — 9:00 PM US Eastern is 1:00 AM UTC the next day — so it landed on the *next* UTC date and "today" appeared to reset hours before local midnight. This hit both chores and routines, and was most visible on the new always-on kid displays.

## Fix

New shared helper `src/api/date-keys.ts` → `localDayKey(value)` returns the local `YYYY-MM-DD` a timestamp belongs to (empty/invalid → `""`, preserving the "never completed" sentinel). Applied consistently to:

- `FamilyStore`: `getCompletionsToday`, `getCompletionsForPeriod`, `completeChore` dedup, `uncompleteChore`, `updateStreakForMember` (today/yesterday/last), and the three routine equivalents.
- `Leaderboard` week/month range helpers, so period bucketing stays aligned with the completion bucketing.

**No data migration**: stored `completed_at` values are full timestamps, so existing records re-bucket correctly going forward — this is a pure reinterpretation of which day a timestamp belongs to.

## Verification

- `tsc && vite build` clean.
- Browser E2E in US Eastern (UTC−4, the bug-exhibiting case): a routine task completed at **9 PM local yesterday** (= 1 AM UTC today, so its UTC date equals today's) is correctly **excluded** from today; a task completed **now** is correctly **included** — display reads 1/2. Console clean.