### PR TITLE
feat: implement classic dashboard layout preset

### DIFF
--- a/beacon/src/components/DashboardView.tsx
+++ b/beacon/src/components/DashboardView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { format, parseISO, isSameDay, startOfDay } from 'date-fns';
+import { format, parseISO, isSameDay, startOfDay, addDays } from 'date-fns';
 import { CalendarEvent, WeatherData } from '../types';
 import { Chore, FamilyMember } from '../types/family';
 import { weatherIcon, conditionLabel } from '../types/weather-icons';
@@ -70,28 +70,149 @@ export function DashboardView({
 
   const hasMemberCalendars = members.some((m) => m.calendar_entity);
 
+  // Group the next 7 days of events for the Classic "This Week" column
+  const weekEvents = useMemo(() => {
+    const start = startOfDay(new Date());
+    return Array.from({ length: 7 }, (_, i) => {
+      const day = addDays(start, i);
+      const dayEvents = events
+        .filter((e) => isSameDay(startOfDay(parseISO(e.start)), day))
+        .sort((a, b) => a.start.localeCompare(b.start));
+      return { day, events: dayEvents };
+    });
+  }, [events]);
+
+  // ─── Shared pieces reused across layouts ───
+  const topbar = (
+    <header className="dash-topbar">
+      <div className="dash-topbar-left">
+        <span className="dash-topbar-time">{timeString}</span>
+        <span className="dash-topbar-date">{dateString}</span>
+      </div>
+      {weather && (
+        <div
+          className={`dash-topbar-weather ${onWeatherClick ? 'dash-topbar-weather--clickable' : ''}`}
+          onClick={onWeatherClick}
+          role={onWeatherClick ? 'button' : undefined}
+          tabIndex={onWeatherClick ? 0 : undefined}
+          onKeyDown={onWeatherClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') onWeatherClick(); } : undefined}
+        >
+          <span className="dash-topbar-weather-icon">{weatherIcon(weather.condition)}</span>
+          <span className="dash-topbar-weather-temp">{Math.round(weather.temperature)}°</span>
+          <span className="dash-topbar-weather-cond">{conditionLabel(weather.condition)}</span>
+        </div>
+      )}
+    </header>
+  );
+
+  const sidebarSections = (
+    <>
+      {todaysMenu.meals.length > 0 && (
+        <section className="dash-sidebar-section">
+          <h3 className="dash-sidebar-heading">Menu</h3>
+          <ul className="dash-menu-list">
+            {todaysMenu.meals.map((meal, i) => (
+              <li key={i} className="dash-menu-item">
+                <span className="dash-menu-icon">{MEAL_ICONS[meal.meal_type] || '🍽️'}</span>
+                <div className="dash-menu-info">
+                  <span className="dash-menu-type">{meal.meal_type}</span>
+                  <span className="dash-menu-name">{meal.name}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      <section className="dash-sidebar-section">
+        <h3 className="dash-sidebar-heading">Tasks</h3>
+        {(() => {
+          const pending = todoItems.filter((t) => t.status === 'needs_action');
+          if (todoItems.length > 0) {
+            return pending.length > 0 ? (
+              <ul className="task-checklist">
+                {pending.map((item) => (
+                  <li key={item.uid} className="task-checklist-item">
+                    <button
+                      type="button"
+                      className="task-checkbox"
+                      onClick={() => onToggleTodo?.(item.uid, item.status)}
+                      aria-label={`Complete ${item.summary}`}
+                    >
+                      <span className="task-checkbox-box" />
+                    </button>
+                    <span className="task-checklist-label">{item.summary}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="task-checklist-done">All done!</div>
+            );
+          }
+          return (
+            <TaskChecklist
+              chores={chores}
+              completedIds={completedChoreIds}
+              onToggle={onToggleChore}
+            />
+          );
+        })()}
+      </section>
+    </>
+  );
+
+  // ─── Classic: clock + three agenda columns (Today | This Week | Tasks) ───
+  if (layout === 'classic') {
+    return (
+      <div className="dashboard dashboard--classic">
+        {topbar}
+        <main className="dash-classic">
+          <section className="dash-classic-col">
+            <h2 className="dashboard-section-title">Today</h2>
+            <div className="dashboard-events-scroll">
+              {todayEvents.length === 0 ? (
+                <div className="dashboard-empty">Nothing scheduled today</div>
+              ) : (
+                <div className="dashboard-events-list">
+                  {todayEvents.map((event) => (
+                    <EventCard key={event.id} event={event} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="dash-classic-col">
+            <h2 className="dashboard-section-title">This Week</h2>
+            <div className="dashboard-events-scroll">
+              {weekEvents.map(({ day, events: dayEvents }) => (
+                <div key={day.toISOString()} className="dash-week-day">
+                  <div className="dash-week-day-label">{format(day, 'EEE d')}</div>
+                  {dayEvents.length === 0 ? (
+                    <div className="dash-week-empty">—</div>
+                  ) : (
+                    <div className="dashboard-events-list">
+                      {dayEvents.map((event) => (
+                        <EventCard key={event.id} event={event} />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <aside className="dash-classic-col dash-classic-sidebar">
+            {sidebarSections}
+          </aside>
+        </main>
+      </div>
+    );
+  }
+
   return (
     <div className={`dashboard dashboard--${layout}`}>
       {/* ─── TOP BAR: Time + Date + Weather ─── */}
-      <header className="dash-topbar">
-        <div className="dash-topbar-left">
-          <span className="dash-topbar-time">{timeString}</span>
-          <span className="dash-topbar-date">{dateString}</span>
-        </div>
-        {weather && (
-          <div
-            className={`dash-topbar-weather ${onWeatherClick ? 'dash-topbar-weather--clickable' : ''}`}
-            onClick={onWeatherClick}
-            role={onWeatherClick ? 'button' : undefined}
-            tabIndex={onWeatherClick ? 0 : undefined}
-            onKeyDown={onWeatherClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') onWeatherClick(); } : undefined}
-          >
-            <span className="dash-topbar-weather-icon">{weatherIcon(weather.condition)}</span>
-            <span className="dash-topbar-weather-temp">{Math.round(weather.temperature)}°</span>
-            <span className="dash-topbar-weather-cond">{conditionLabel(weather.condition)}</span>
-          </div>
-        )}
-      </header>
+      {topbar}
 
       {/* ─── MAIN: Per-member calendar columns ─── */}
       <main className="dash-main">
@@ -161,56 +282,7 @@ export function DashboardView({
 
       {/* ─── SIDEBAR: Menu + Tasks + Chores ─── */}
       <aside className="dash-sidebar">
-        {todaysMenu.meals.length > 0 && (
-          <section className="dash-sidebar-section">
-            <h3 className="dash-sidebar-heading">Menu</h3>
-            <ul className="dash-menu-list">
-              {todaysMenu.meals.map((meal, i) => (
-                <li key={i} className="dash-menu-item">
-                  <span className="dash-menu-icon">{MEAL_ICONS[meal.meal_type] || '🍽️'}</span>
-                  <div className="dash-menu-info">
-                    <span className="dash-menu-type">{meal.meal_type}</span>
-                    <span className="dash-menu-name">{meal.name}</span>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-        <section className="dash-sidebar-section">
-          <h3 className="dash-sidebar-heading">Tasks</h3>
-          {(() => {
-            const pending = todoItems.filter((t) => t.status === 'needs_action');
-            if (todoItems.length > 0) {
-              return pending.length > 0 ? (
-                <ul className="task-checklist">
-                  {pending.map((item) => (
-                    <li key={item.uid} className="task-checklist-item">
-                      <button
-                        type="button"
-                        className="task-checkbox"
-                        onClick={() => onToggleTodo?.(item.uid, item.status)}
-                        aria-label={`Complete ${item.summary}`}
-                      >
-                        <span className="task-checkbox-box" />
-                      </button>
-                      <span className="task-checklist-label">{item.summary}</span>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <div className="task-checklist-done">All done!</div>
-              );
-            }
-            return (
-              <TaskChecklist
-                chores={chores}
-                completedIds={completedChoreIds}
-                onToggle={onToggleChore}
-              />
-            );
-          })()}
-        </section>
+        {sidebarSections}
       </aside>
     </div>
   );

--- a/beacon/src/styles/dashboard.css
+++ b/beacon/src/styles/dashboard.css
@@ -16,22 +16,60 @@
   overflow: hidden;
 }
 
-/* Classic layout: 3 equal columns (original Beacon look) */
+/* Classic layout: topbar + three agenda columns (Today | This Week | Tasks) */
 .dashboard--classic {
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    "topbar"
+    "classic";
+  padding: 32px 40px;
+  gap: 20px;
+}
+
+.dash-classic {
+  grid-area: classic;
+  display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 1fr;
-  grid-template-areas: "main main sidebar";
-  padding: 40px 48px;
-  gap: 32px;
+  gap: 28px;
+  min-height: 0;
+  overflow: hidden;
 }
 
-.dashboard--classic .dash-topbar {
-  display: none;
+.dash-classic-col {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  gap: 12px;
 }
 
-.dashboard--classic .dash-sidebar {
-  border-left: none;
-  padding-left: 0;
+.dash-classic-sidebar {
+  gap: 24px;
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.dash-week-day {
+  margin-bottom: 14px;
+}
+
+.dash-week-day-label {
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.dash-week-empty {
+  font-size: 13px;
+  color: var(--text-light);
+  font-style: italic;
+  padding-bottom: 4px;
 }
 
 /* Compact layout: single column, scrollable */
@@ -504,6 +542,21 @@
   .event-card { padding: 12px 14px; }
 
   .task-checklist-item { min-height: 48px; }
+
+  /* Classic layout collapses to a single scrolling column on small screens */
+  .dashboard--classic {
+    grid-template-rows: auto auto;
+    height: auto;
+    overflow-y: auto;
+    padding: 16px;
+    padding-bottom: 80px;
+  }
+
+  .dash-classic {
+    grid-template-columns: 1fr;
+    overflow: visible;
+    gap: 20px;
+  }
 }
 
 /* ─── Responsive: Phone < 480px ─── */

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { format, parseISO, isSameDay, startOfDay } from 'date-fns';
+import { format, parseISO, isSameDay, startOfDay, addDays } from 'date-fns';
 import { CalendarEvent, WeatherData } from '../types';
 import { Chore, FamilyMember } from '../types/family';
 import { weatherIcon, conditionLabel } from '../types/weather-icons';
@@ -70,28 +70,149 @@ export function DashboardView({
 
   const hasMemberCalendars = members.some((m) => m.calendar_entity);
 
+  // Group the next 7 days of events for the Classic "This Week" column
+  const weekEvents = useMemo(() => {
+    const start = startOfDay(new Date());
+    return Array.from({ length: 7 }, (_, i) => {
+      const day = addDays(start, i);
+      const dayEvents = events
+        .filter((e) => isSameDay(startOfDay(parseISO(e.start)), day))
+        .sort((a, b) => a.start.localeCompare(b.start));
+      return { day, events: dayEvents };
+    });
+  }, [events]);
+
+  // ─── Shared pieces reused across layouts ───
+  const topbar = (
+    <header className="dash-topbar">
+      <div className="dash-topbar-left">
+        <span className="dash-topbar-time">{timeString}</span>
+        <span className="dash-topbar-date">{dateString}</span>
+      </div>
+      {weather && (
+        <div
+          className={`dash-topbar-weather ${onWeatherClick ? 'dash-topbar-weather--clickable' : ''}`}
+          onClick={onWeatherClick}
+          role={onWeatherClick ? 'button' : undefined}
+          tabIndex={onWeatherClick ? 0 : undefined}
+          onKeyDown={onWeatherClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') onWeatherClick(); } : undefined}
+        >
+          <span className="dash-topbar-weather-icon">{weatherIcon(weather.condition)}</span>
+          <span className="dash-topbar-weather-temp">{Math.round(weather.temperature)}°</span>
+          <span className="dash-topbar-weather-cond">{conditionLabel(weather.condition)}</span>
+        </div>
+      )}
+    </header>
+  );
+
+  const sidebarSections = (
+    <>
+      {todaysMenu.meals.length > 0 && (
+        <section className="dash-sidebar-section">
+          <h3 className="dash-sidebar-heading">Menu</h3>
+          <ul className="dash-menu-list">
+            {todaysMenu.meals.map((meal, i) => (
+              <li key={i} className="dash-menu-item">
+                <span className="dash-menu-icon">{MEAL_ICONS[meal.meal_type] || '🍽️'}</span>
+                <div className="dash-menu-info">
+                  <span className="dash-menu-type">{meal.meal_type}</span>
+                  <span className="dash-menu-name">{meal.name}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      <section className="dash-sidebar-section">
+        <h3 className="dash-sidebar-heading">Tasks</h3>
+        {(() => {
+          const pending = todoItems.filter((t) => t.status === 'needs_action');
+          if (todoItems.length > 0) {
+            return pending.length > 0 ? (
+              <ul className="task-checklist">
+                {pending.map((item) => (
+                  <li key={item.uid} className="task-checklist-item">
+                    <button
+                      type="button"
+                      className="task-checkbox"
+                      onClick={() => onToggleTodo?.(item.uid, item.status)}
+                      aria-label={`Complete ${item.summary}`}
+                    >
+                      <span className="task-checkbox-box" />
+                    </button>
+                    <span className="task-checklist-label">{item.summary}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="task-checklist-done">All done!</div>
+            );
+          }
+          return (
+            <TaskChecklist
+              chores={chores}
+              completedIds={completedChoreIds}
+              onToggle={onToggleChore}
+            />
+          );
+        })()}
+      </section>
+    </>
+  );
+
+  // ─── Classic: clock + three agenda columns (Today | This Week | Tasks) ───
+  if (layout === 'classic') {
+    return (
+      <div className="dashboard dashboard--classic">
+        {topbar}
+        <main className="dash-classic">
+          <section className="dash-classic-col">
+            <h2 className="dashboard-section-title">Today</h2>
+            <div className="dashboard-events-scroll">
+              {todayEvents.length === 0 ? (
+                <div className="dashboard-empty">Nothing scheduled today</div>
+              ) : (
+                <div className="dashboard-events-list">
+                  {todayEvents.map((event) => (
+                    <EventCard key={event.id} event={event} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="dash-classic-col">
+            <h2 className="dashboard-section-title">This Week</h2>
+            <div className="dashboard-events-scroll">
+              {weekEvents.map(({ day, events: dayEvents }) => (
+                <div key={day.toISOString()} className="dash-week-day">
+                  <div className="dash-week-day-label">{format(day, 'EEE d')}</div>
+                  {dayEvents.length === 0 ? (
+                    <div className="dash-week-empty">—</div>
+                  ) : (
+                    <div className="dashboard-events-list">
+                      {dayEvents.map((event) => (
+                        <EventCard key={event.id} event={event} />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <aside className="dash-classic-col dash-classic-sidebar">
+            {sidebarSections}
+          </aside>
+        </main>
+      </div>
+    );
+  }
+
   return (
     <div className={`dashboard dashboard--${layout}`}>
       {/* ─── TOP BAR: Time + Date + Weather ─── */}
-      <header className="dash-topbar">
-        <div className="dash-topbar-left">
-          <span className="dash-topbar-time">{timeString}</span>
-          <span className="dash-topbar-date">{dateString}</span>
-        </div>
-        {weather && (
-          <div
-            className={`dash-topbar-weather ${onWeatherClick ? 'dash-topbar-weather--clickable' : ''}`}
-            onClick={onWeatherClick}
-            role={onWeatherClick ? 'button' : undefined}
-            tabIndex={onWeatherClick ? 0 : undefined}
-            onKeyDown={onWeatherClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') onWeatherClick(); } : undefined}
-          >
-            <span className="dash-topbar-weather-icon">{weatherIcon(weather.condition)}</span>
-            <span className="dash-topbar-weather-temp">{Math.round(weather.temperature)}°</span>
-            <span className="dash-topbar-weather-cond">{conditionLabel(weather.condition)}</span>
-          </div>
-        )}
-      </header>
+      {topbar}
 
       {/* ─── MAIN: Per-member calendar columns ─── */}
       <main className="dash-main">
@@ -161,56 +282,7 @@ export function DashboardView({
 
       {/* ─── SIDEBAR: Menu + Tasks + Chores ─── */}
       <aside className="dash-sidebar">
-        {todaysMenu.meals.length > 0 && (
-          <section className="dash-sidebar-section">
-            <h3 className="dash-sidebar-heading">Menu</h3>
-            <ul className="dash-menu-list">
-              {todaysMenu.meals.map((meal, i) => (
-                <li key={i} className="dash-menu-item">
-                  <span className="dash-menu-icon">{MEAL_ICONS[meal.meal_type] || '🍽️'}</span>
-                  <div className="dash-menu-info">
-                    <span className="dash-menu-type">{meal.meal_type}</span>
-                    <span className="dash-menu-name">{meal.name}</span>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-        <section className="dash-sidebar-section">
-          <h3 className="dash-sidebar-heading">Tasks</h3>
-          {(() => {
-            const pending = todoItems.filter((t) => t.status === 'needs_action');
-            if (todoItems.length > 0) {
-              return pending.length > 0 ? (
-                <ul className="task-checklist">
-                  {pending.map((item) => (
-                    <li key={item.uid} className="task-checklist-item">
-                      <button
-                        type="button"
-                        className="task-checkbox"
-                        onClick={() => onToggleTodo?.(item.uid, item.status)}
-                        aria-label={`Complete ${item.summary}`}
-                      >
-                        <span className="task-checkbox-box" />
-                      </button>
-                      <span className="task-checklist-label">{item.summary}</span>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <div className="task-checklist-done">All done!</div>
-              );
-            }
-            return (
-              <TaskChecklist
-                chores={chores}
-                completedIds={completedChoreIds}
-                onToggle={onToggleChore}
-              />
-            );
-          })()}
-        </section>
+        {sidebarSections}
       </aside>
     </div>
   );

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -16,22 +16,60 @@
   overflow: hidden;
 }
 
-/* Classic layout: 3 equal columns (original Beacon look) */
+/* Classic layout: topbar + three agenda columns (Today | This Week | Tasks) */
 .dashboard--classic {
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    "topbar"
+    "classic";
+  padding: 32px 40px;
+  gap: 20px;
+}
+
+.dash-classic {
+  grid-area: classic;
+  display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 1fr;
-  grid-template-areas: "main main sidebar";
-  padding: 40px 48px;
-  gap: 32px;
+  gap: 28px;
+  min-height: 0;
+  overflow: hidden;
 }
 
-.dashboard--classic .dash-topbar {
-  display: none;
+.dash-classic-col {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  gap: 12px;
 }
 
-.dashboard--classic .dash-sidebar {
-  border-left: none;
-  padding-left: 0;
+.dash-classic-sidebar {
+  gap: 24px;
+  overflow-y: auto;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.dash-week-day {
+  margin-bottom: 14px;
+}
+
+.dash-week-day-label {
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.dash-week-empty {
+  font-size: 13px;
+  color: var(--text-light);
+  font-style: italic;
+  padding-bottom: 4px;
 }
 
 /* Compact layout: single column, scrollable */
@@ -504,6 +542,21 @@
   .event-card { padding: 12px 14px; }
 
   .task-checklist-item { min-height: 48px; }
+
+  /* Classic layout collapses to a single scrolling column on small screens */
+  .dashboard--classic {
+    grid-template-rows: auto auto;
+    height: auto;
+    overflow-y: auto;
+    padding: 16px;
+    padding-bottom: 80px;
+  }
+
+  .dash-classic {
+    grid-template-columns: 1fr;
+    overflow: visible;
+    gap: 20px;
+  }
 }
 
 /* ─── Responsive: Phone < 480px ─── */


### PR DESCRIPTION
Completes the long-parked "classic layout" WIP, rebased onto the current (post-stacked-dashboard) DashboardView.

## What this does

The `classic` dashboard preset existed only as a name — on `main` it just reshaped the default per-member grid via CSS (hid the topbar, squeezed columns to 3). This implements it as a **distinct three-column agenda**:

- **Today** — today's events
- **This Week** — the next 7 days, events grouped per day
- **Tasks** — the menu + tasks/chores sidebar

The clock topbar is retained. Users pick it in Settings → General → Dashboard Layout (the wiring already existed).

## Implementation notes

- Extracted the shared **topbar** and **sidebar sections** into reused consts, so `default` and `compact` render identically to before (verified — no regression).
- Added a `weekEvents` memo grouping the next 7 days.
- Replaced the classic CSS stub with real grid styles, including a single-column collapse under 768px.
- `EventCard`, `TaskChecklist`, and all data props are reused unchanged.

## What was dropped (already shipped upstream)

The parked branch was `classic-layout-and-week-nav`. The **week-navigation** half — prev/today/next week controls — already shipped in v1.29.0 (919f5f5), in a more complete form that also refetches events for the visible week. The WIP's version is redundant and was not carried over.

## Verification

- `tsc && vite build` clean.
- Browser: all three presets render correctly with no console errors — classic shows the 3-column agenda with events grouped by day and color-coded; default shows per-member columns (Ava/Ben/Other) + sidebar; compact is single-column. Screenshots captured during review.

Not auto-merged — a layout is a taste call, so this is left for you to eyeball and merge.