### PR TITLE
fix: apply calendar visibility and custom colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,14 @@ export function App() {
   const { client, connected } = useHomeAssistant();
   const { isIngress, compact } = useIngressDetect();
   const {
+    settings,
+    updateSettings,
+    resetSettings,
+    exportSettings,
+    importSettings,
+    clearLocalStorage,
+  } = useSettings();
+  const {
     calendars: haCalendars,
     events: haEvents,
     fetchCalendars,
@@ -55,14 +63,32 @@ export function App() {
 
   const localCal = useLocalCalendar();
 
-  // Merge HA + local calendars and events
+  // Merge HA + local calendars, applying any custom colors from Settings.
+  // Unfiltered — SettingsView needs the full list to let hidden calendars be re-enabled.
   const calendars = useMemo(
-    () => [localCal.calendar, ...haCalendars],
-    [localCal.calendar, haCalendars],
+    () => [localCal.calendar, ...haCalendars].map((cal) => ({
+      ...cal,
+      color: settings.calendarColors[cal.id] || cal.color,
+    })),
+    [localCal.calendar, haCalendars, settings.calendarColors],
   );
+
+  // Calendars with permanently-hidden ones removed, for pill filters / event creation.
+  const visibleCalendars = useMemo(
+    () => calendars.filter((cal) => !settings.permanentlyHiddenCalendars.includes(cal.id)),
+    [calendars, settings.permanentlyHiddenCalendars],
+  );
+
+  // Merged events, excluding permanently-hidden calendars and with custom colors applied.
   const events = useMemo(
-    () => [...localCal.events, ...haEvents].sort((a, b) => a.start.localeCompare(b.start)),
-    [localCal.events, haEvents],
+    () => [...localCal.events, ...haEvents]
+      .filter((ev) => !settings.permanentlyHiddenCalendars.includes(ev.calendarId))
+      .map((ev) => ({
+        ...ev,
+        color: settings.calendarColors[ev.calendarId] || ev.color,
+      }))
+      .sort((a, b) => a.start.localeCompare(b.start)),
+    [localCal.events, haEvents, settings.permanentlyHiddenCalendars, settings.calendarColors],
   );
 
   // Route create/update/delete to local or HA based on calendar ID
@@ -107,15 +133,6 @@ export function App() {
   } = useChores();
 
   const dashboardTasks = useDashboardTasks(connected);
-
-  const {
-    settings,
-    updateSettings,
-    resetSettings,
-    exportSettings,
-    importSettings,
-    clearLocalStorage,
-  } = useSettings();
 
   // Apply theme at App level so it stays active regardless of which view is shown
   const { setTheme } = useTheme();
@@ -574,7 +591,7 @@ export function App() {
             {/* Family filter pills — above the calendar */}
             <div className="filter-bar">
               <FamilyFilter
-                calendars={calendars}
+                calendars={visibleCalendars}
                 hiddenCalendars={hiddenCalendars}
                 onToggle={handleToggleCalendar}
               />
@@ -618,7 +635,7 @@ export function App() {
       {showModal && (
         <EventModal
           event={selectedEvent}
-          calendars={calendars}
+          calendars={visibleCalendars}
           onSave={handleSaveEvent}
           onDelete={handleDeleteEvent}
           onClose={handleCloseModal}

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,13 +59,35 @@ const PASTEL_MAP: Record<string, string> = {
   '#14b8a6': '#99f6e4', // teal
 };
 
+const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+function normalizeHex(hex: string): string {
+  if (hex.length === 4) {
+    const [, r, g, b] = hex;
+    return `#${r}${r}${g}${g}${b}${b}`;
+  }
+  return hex;
+}
+
+/* Blends a hex color toward white to produce a pastel tint for custom (non-palette) colors */
+function blendWithWhite(hex: string, ratio: number): string {
+  const normalized = normalizeHex(hex);
+  const channel = (start: number) => parseInt(normalized.slice(start, start + 2), 16);
+  const mix = (value: number) => Math.round(value + (255 - value) * ratio).toString(16).padStart(2, '0');
+  return `#${mix(channel(1))}${mix(channel(3))}${mix(channel(5))}`;
+}
+
 export function getPastelColor(fullColor: string): string {
-  return PASTEL_MAP[fullColor] || '#e5e7eb';
+  if (PASTEL_MAP[fullColor]) return PASTEL_MAP[fullColor];
+  if (HEX_COLOR_RE.test(fullColor)) return blendWithWhite(fullColor, 0.75);
+  return '#e5e7eb';
 }
 
 export function getFullColor(fullColor: string): string {
   // If the color is already a known full color, return it
   if (PASTEL_MAP[fullColor]) return fullColor;
-  // Fallback
+  // Custom (non-palette) colors are used as-is
+  if (HEX_COLOR_RE.test(fullColor)) return fullColor;
+  // Fallback for missing/invalid colors
   return '#6b7280';
 }


### PR DESCRIPTION
**Fix calendar visibility and custom color settings**

The Connected Calendars settings UI currently persists `permanentlyHiddenCalendars `and `calendarColors`, but those settings are not consumed by the calendar display. As a result, disabling a calendar or assigning it a custom color has no effect on the rendered calendar.

This change applies the persisted settings when deriving calendars and events in `App.tsx`, while retaining the complete calendar list for Settings so hidden calendars can be re-enabled.

It also updates color handling so arbitrary user-selected colors can be rendered by event components instead of falling back to gray.

**Manually tested on Home Assistant 2026.7.4:**

- Calendar visibility changes reflected in calendar view
- Disabled calendars removed from the calendar filter
- Custom calendar colors reflected in event blocks
- Multiple Google Calendar entities tested
- Existing calendars without custom colors retain their default colors
- Project builds successfully with `npm run build`

Testing was performed using a locally built HA app alongside the released Beacon app for comparison.