### PR TITLE
fix: Family dashboard columns + rebuild add-on image on every release

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -1,6 +1,7 @@
 name: Build & Publish Add-on
 
 on:
+  workflow_call:
   release:
     types: [published]
   push:
@@ -22,17 +23,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # release/push-tag triggers (e.g. a manually-created tag/release) may
+      # predate a config.yaml version bump, so sync config.yaml to the tag
+      # first. When invoked via workflow_call (our own release.yml, right
+      # after semantic-release already committed the bump to main), skip
+      # this — config.yaml on the checked-out commit is already correct.
       - name: Extract version from tag
-        id: version
+        id: tag_version
+        if: github.event_name != 'workflow_call'
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Update config.yaml version
+      - name: Sync config.yaml to tag version
+        if: github.event_name != 'workflow_call'
         run: |
-          sed -i "s/^version:.*/version: \"${{ steps.version.outputs.version }}\"/" config.yaml
+          sed -i "s/^version:.*/version: \"${{ steps.tag_version.outputs.version }}\"/" config.yaml
+
+      - name: Read version to build
+        id: version
+        run: |
+          VERSION=$(grep '^version:' config.yaml | sed -E 's/version:[[:space:]]*"?([^"]*)"?/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -59,7 +72,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Commit updated config.yaml
+      - name: Commit synced config.yaml (release/push-tag triggers only)
+        if: github.event_name != 'workflow_call'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      released: ${{ steps.semantic.outputs.released }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,6 +27,29 @@ jobs:
       - run: npm ci
 
       - name: Release
+        id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: |
+          npx semantic-release
+          # semantic-release doesn't set a step output itself; detect whether
+          # it actually cut a release by checking if HEAD gained a new tag.
+          if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # semantic-release creates GitHub releases using the default GITHUB_TOKEN,
+  # and GitHub deliberately does not fire downstream `release`/`push: tags`
+  # workflow events for GITHUB_TOKEN-authored activity (loop prevention).
+  # That silently starved build-addon.yml of its trigger for every release
+  # since ~v1.3.0 — the Docker image hasn't been rebuilt in months. Calling
+  # it directly here closes that gap without needing a PAT.
+  build-addon:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: ./.github/workflows/build-addon.yml
+    permissions:
+      contents: write
+      packages: write

--- a/beacon/src/components/dashboard-family-layout.test.ts
+++ b/beacon/src/components/dashboard-family-layout.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Regression guard for a UI bug where the "Family" dashboard layout
+ * (DashboardView's default layout, described in Settings as "Per-member
+ * calendar columns") was actually rendering family members as full-width
+ * horizontal rows stacked vertically (`.dash-family-grid { flex-direction:
+ * column }`) instead of side-by-side vertical columns. jsdom doesn't run a
+ * real layout engine, so this can't screenshot-diff the result — instead it
+ * asserts the actual CSS source defines a column-based grid, which is the
+ * property that broke silently before (class names like "dash-member-col"
+ * suggested columns while the CSS quietly did rows).
+ */
+
+const DASHBOARD_CSS = path.resolve(__dirname, '../styles/dashboard.css');
+
+describe('dashboard "Family" layout renders members as columns, not stacked rows', () => {
+  const css = readFileSync(DASHBOARD_CSS, 'utf-8');
+
+  function ruleBodyFor(selector: string): string {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+    if (!match) throw new Error(`Rule "${selector}" not found in dashboard.css`);
+    return match[1];
+  }
+
+  it('.dash-family-grid uses a multi-column grid keyed off --member-count', () => {
+    const body = ruleBodyFor('.dash-family-grid');
+    expect(body).toMatch(/display:\s*grid/);
+    expect(body).toMatch(/grid-template-columns:.*--member-count/);
+    // The bug: this used to be `display: flex; flex-direction: column`,
+    // which stacks each member's entire section as a full-width row.
+    expect(body).not.toMatch(/flex-direction:\s*column/);
+  });
+
+  it('.dash-member-col is a vertical flex column (content stacks top-to-bottom WITHIN each member column)', () => {
+    // This one legitimately should be flex-direction: column — that's
+    // correct for the events *inside* a single member's column. The bug
+    // was one level up, at .dash-family-grid.
+    const body = ruleBodyFor('.dash-member-col');
+    expect(body).toMatch(/flex-direction:\s*column/);
+  });
+
+  it('collapses back to a single stacked column below the tablet breakpoint (768px)', () => {
+    const mediaMatch = css.match(/@media \(max-width: 768px\) \{([\s\S]*?)\n\}\n\n\/\* ─── Responsive: Phone/);
+    expect(mediaMatch, 'tablet media query block not found').toBeTruthy();
+    const tabletBlock = mediaMatch![1];
+    const gridOverride = tabletBlock.match(/\.dash-family-grid\s*\{([^}]*)\}/);
+    expect(gridOverride, '.dash-family-grid override not found in tablet breakpoint').toBeTruthy();
+    expect(gridOverride![1]).toMatch(/grid-template-columns:\s*1fr/);
+  });
+});

--- a/beacon/src/styles/dashboard.css
+++ b/beacon/src/styles/dashboard.css
@@ -172,17 +172,16 @@
 /* ─── MAIN: Family calendar columns ─── */
 .dash-main {
   grid-area: main;
-  overflow-y: auto;
   min-height: 0;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
 }
 
 .dash-family-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(var(--member-count, 1), minmax(140px, 1fr));
+  gap: 20px;
   align-items: stretch;
+  height: 100%;
+  min-height: 0;
 }
 
 .dash-member-col {
@@ -190,6 +189,7 @@
   flex-direction: column;
   gap: 10px;
   min-width: 0;
+  min-height: 0;
 }
 
 .dash-member-header {
@@ -224,6 +224,11 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 .dash-member-empty {
@@ -520,6 +525,7 @@
   .dash-topbar-date { font-size: 16px; }
 
   .dash-family-grid {
+    grid-template-columns: 1fr;
     gap: 12px;
   }
 

--- a/src/components/dashboard-family-layout.test.ts
+++ b/src/components/dashboard-family-layout.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Regression guard for a UI bug where the "Family" dashboard layout
+ * (DashboardView's default layout, described in Settings as "Per-member
+ * calendar columns") was actually rendering family members as full-width
+ * horizontal rows stacked vertically (`.dash-family-grid { flex-direction:
+ * column }`) instead of side-by-side vertical columns. jsdom doesn't run a
+ * real layout engine, so this can't screenshot-diff the result — instead it
+ * asserts the actual CSS source defines a column-based grid, which is the
+ * property that broke silently before (class names like "dash-member-col"
+ * suggested columns while the CSS quietly did rows).
+ */
+
+const DASHBOARD_CSS = path.resolve(__dirname, '../styles/dashboard.css');
+
+describe('dashboard "Family" layout renders members as columns, not stacked rows', () => {
+  const css = readFileSync(DASHBOARD_CSS, 'utf-8');
+
+  function ruleBodyFor(selector: string): string {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+    if (!match) throw new Error(`Rule "${selector}" not found in dashboard.css`);
+    return match[1];
+  }
+
+  it('.dash-family-grid uses a multi-column grid keyed off --member-count', () => {
+    const body = ruleBodyFor('.dash-family-grid');
+    expect(body).toMatch(/display:\s*grid/);
+    expect(body).toMatch(/grid-template-columns:.*--member-count/);
+    // The bug: this used to be `display: flex; flex-direction: column`,
+    // which stacks each member's entire section as a full-width row.
+    expect(body).not.toMatch(/flex-direction:\s*column/);
+  });
+
+  it('.dash-member-col is a vertical flex column (content stacks top-to-bottom WITHIN each member column)', () => {
+    // This one legitimately should be flex-direction: column — that's
+    // correct for the events *inside* a single member's column. The bug
+    // was one level up, at .dash-family-grid.
+    const body = ruleBodyFor('.dash-member-col');
+    expect(body).toMatch(/flex-direction:\s*column/);
+  });
+
+  it('collapses back to a single stacked column below the tablet breakpoint (768px)', () => {
+    const mediaMatch = css.match(/@media \(max-width: 768px\) \{([\s\S]*?)\n\}\n\n\/\* ─── Responsive: Phone/);
+    expect(mediaMatch, 'tablet media query block not found').toBeTruthy();
+    const tabletBlock = mediaMatch![1];
+    const gridOverride = tabletBlock.match(/\.dash-family-grid\s*\{([^}]*)\}/);
+    expect(gridOverride, '.dash-family-grid override not found in tablet breakpoint').toBeTruthy();
+    expect(gridOverride![1]).toMatch(/grid-template-columns:\s*1fr/);
+  });
+});

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -172,17 +172,16 @@
 /* ─── MAIN: Family calendar columns ─── */
 .dash-main {
   grid-area: main;
-  overflow-y: auto;
   min-height: 0;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
 }
 
 .dash-family-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(var(--member-count, 1), minmax(140px, 1fr));
+  gap: 20px;
   align-items: stretch;
+  height: 100%;
+  min-height: 0;
 }
 
 .dash-member-col {
@@ -190,6 +189,7 @@
   flex-direction: column;
   gap: 10px;
   min-width: 0;
+  min-height: 0;
 }
 
 .dash-member-header {
@@ -224,6 +224,11 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 .dash-member-empty {
@@ -520,6 +525,7 @@
   .dash-topbar-date { font-size: 16px; }
 
   .dash-family-grid {
+    grid-template-columns: 1fr;
     gap: 12px;
   }
 


### PR DESCRIPTION
## Two independent fixes

### 1. Family dashboard layout was rows, not columns (patch)
The "Family" layout (described in Settings as "Per-member calendar columns") was actually rendering each member as a full-width horizontal row stacked vertically — `.dash-family-grid` was `flex-direction: column` despite `.dash-member-col` implying an actual column layout. Confirmed visually with 4 seeded family members before/after.

Fixed by switching `.dash-family-grid` to `display: grid` with `grid-template-columns: repeat(var(--member-count), minmax(140px, 1fr))` — the `--member-count` CSS var was already being set inline by `DashboardView.tsx`, nothing was consuming it. Each member's own column still stacks its events top-to-bottom (that part was already correct). Also gave each column independent scroll (so one busy member doesn't push others' headers off-screen) and added a tablet breakpoint fallback so it degrades back to stacked rows below 768px, where columns genuinely don't make sense.

Added a regression test asserting the grid CSS + `--member-count` wiring + the 768px fallback directly against the stylesheet source (jsdom has no real layout engine to screenshot-diff against).

### 2. Add-on Docker image hasn't rebuilt since March (ci fix)
Root cause: semantic-release creates GitHub releases using `secrets.GITHUB_TOKEN`, and GitHub deliberately suppresses downstream `release`/`push:tags` workflow triggers for `GITHUB_TOKEN`-authored activity (infinite-loop prevention). Confirmed via the Actions API: **zero** workflow runs have ever been triggered by a `release` event in this repo's history except one — a human-created release (`v1.2.1`, authored by `asachs01` directly, which fires normally). Every release since (~20 of them) silently never triggered `build-addon.yml`.

Fixed by having `release.yml` call `build-addon.yml` directly via `workflow_call` once semantic-release confirms it actually cut a release. No new secrets/PAT required. `build-addon.yml` keeps its existing `release`/`push: tags` triggers for the manual-release path (still valid, still fires normally for human-authored releases).

**Verification:** `npm test` (32/32 passing), `tsc --noEmit` clean, `npm run build` succeeds, both workflow YAMLs validated with `yaml.safe_load`. Visually confirmed the family-layout fix in-browser with 4 seeded members. Synced `beacon/src/` per the dual-directory build rule.