### PR TITLE
fix(ci): build-addon workflow_call detection was broken, image still not building

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -26,18 +26,24 @@ jobs:
       # release/push-tag triggers (e.g. a manually-created tag/release) may
       # predate a config.yaml version bump, so sync config.yaml to the tag
       # first. When invoked via workflow_call (our own release.yml, right
-      # after semantic-release already committed the bump to main), skip
-      # this — config.yaml on the checked-out commit is already correct.
+      # after semantic-release already committed the bump to main), GITHUB_REF
+      # is a branch ref (refs/heads/main), not a tag — config.yaml on that
+      # commit is already correct, so skip the tag-parsing/sync steps.
+      #
+      # NOTE: don't gate this on `github.event_name != 'workflow_call'` --
+      # empirically, github.event_name inside a called reusable workflow does
+      # NOT read back as 'workflow_call' the way you'd expect, so that
+      # condition silently never skips. Check the actual ref shape instead.
       - name: Extract version from tag
         id: tag_version
-        if: github.event_name != 'workflow_call'
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Sync config.yaml to tag version
-        if: github.event_name != 'workflow_call'
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           sed -i "s/^version:.*/version: \"${{ steps.tag_version.outputs.version }}\"/" config.yaml
 
@@ -73,7 +79,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Commit synced config.yaml (release/push-tag triggers only)
-        if: github.event_name != 'workflow_call'
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The build-addon fix from #8 shipped in v1.32.1's release run and **actually failed** — confirmed live: https://github.com/asachs01/beacon/actions/runs/30771046443 (job \`build-addon / build\`).

It gated the tag-parsing/config-sync steps on \`if: github.event_name != 'workflow_call'\`, expecting that to evaluate false (and skip) when \`release.yml\` calls this workflow via \`uses: ./.github/workflows/build-addon.yml\`. It didn't. The steps ran anyway with \`GITHUB_REF\` resolving to \`refs/heads/main\`, and \`sed\` blew up trying to write \`version: \"refs/heads/main\"\` into config.yaml (embedded slashes break the s/// expression):

\`\`\`
sed: -e expression #1, char 30: unknown option to `s'
```

Net effect: v1.32.1's release (tag, GitHub release, changelog) all landed correctly, but the Docker image build still didn't run — the exact bug #8 was supposed to close, just moved one layer down into the reusable workflow itself.

**Fix:** key the conditional off the actual ref shape instead of \`event_name\`, which doesn't read back as \`'workflow_call'\` inside a called reusable workflow the way you'd expect: \`if: startsWith(github.ref, 'refs/tags/')\`. Skips tag-parsing when invoked from \`main\` (branch ref), still runs it for the legacy manual release/push-tag path (tag ref).

No source changes, CI-only. Once this merges, will manually re-trigger the build for v1.32.1 so that release actually gets its image.