### PR TITLE
fix(docker): Dockerfile COPY target missing at repo root, breaking the image build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,21 @@ cp Dockerfile run.sh CHANGELOG.md beacon/
 ```
 Both `config.yaml` and `beacon/config.yaml` must have matching versions.
 
+**The root-level `Dockerfile` builds from repo-root context (`context: .` in
+`.github/workflows/build-addon.yml`), not from `beacon/`.** So anything that
+Dockerfile `COPY`s -- including `custom_intents/` and `custom_sentences/` --
+must also exist at the repo root, mirrored from `beacon/`, or the Docker
+build fails with `"failed to calculate checksum ... not found"`. This bit
+us once already: those two dirs existed only under `beacon/` and the image
+build silently never ran for months (see the CI/release-trigger bug below),
+so nobody caught it until the pipeline was fixed and the build actually
+executed. When adding root-level content Dockerfile depends on, sync it
+the same way:
+```bash
+rsync -av --delete beacon/custom_intents/ custom_intents/
+rsync -av --delete beacon/custom_sentences/ custom_sentences/
+```
+
 ### HA Add-on Auth: Long-Lived Token in Config
 SUPERVISOR_TOKEN only works container-side (http://supervisor/core). postMessage auth doesn't work in HA companion app WKWebView. The `ha_token` config option (schema: password) with a user-provided long-lived access token is the only reliable browser-side auth approach.
 

--- a/custom_intents/beacon.yaml
+++ b/custom_intents/beacon.yaml
@@ -1,0 +1,146 @@
+# Beacon Custom Intent Handlers
+# These call HA services in response to voice commands.
+# Requires: Beacon add-on running, todo entities, calendar entities.
+
+# ── List Management ──────────────────────────────────────────────
+BeaconAddItem:
+  action:
+    - service: todo.add_item
+      data:
+        entity_id: "todo.{{ list_name | lower | replace(' ', '_') }}"
+        item: "{{ item }}"
+  speech:
+    text: "Added {{ item }} to the {{ list_name }} list."
+
+# ── Chore Tracking ──────────────────────────────────────────────
+# Marks a chore as complete in a todo list named "chores".
+# Adjust entity_id if your chore list has a different name.
+BeaconCompleteChore:
+  action:
+    - service: todo.update_item
+      data:
+        entity_id: "todo.chores"
+        item: "{{ chore }}"
+        status: "completed"
+  speech:
+    text: "Marked {{ chore }} as done."
+
+BeaconCompleteChoreByPerson:
+  action:
+    - service: todo.update_item
+      data:
+        entity_id: "todo.chores"
+        item: "{{ chore }}"
+        status: "completed"
+  speech:
+    text: "{{ name }} finished {{ chore }}. Nice work!"
+
+# ── Calendar ────────────────────────────────────────────────────
+# Calendar queries use the built-in conversation response.
+# HA Assist will read today's events from the default calendar.
+BeaconCalendarToday:
+  action:
+    - service: calendar.get_events
+      target:
+        entity_id: "calendar.family"
+      data:
+        start_date_time: "{{ now().strftime('%Y-%m-%dT00:00:00') }}"
+        end_date_time: "{{ now().strftime('%Y-%m-%dT23:59:59') }}"
+      response_variable: result
+  speech:
+    text: >-
+      {% set events = result['calendar.family']['events'] %}
+      {% if events | length == 0 %}
+        Nothing on the calendar today.
+      {% else %}
+        Today you have {{ events | length }} event{{ 's' if events | length > 1 else '' }}:
+        {% for e in events %}
+          {{ e.summary }}{% if not loop.last %}, {% endif %}
+        {% endfor %}.
+      {% endif %}
+
+BeaconCalendarTomorrow:
+  action:
+    - service: calendar.get_events
+      target:
+        entity_id: "calendar.family"
+      data:
+        start_date_time: "{{ (now() + timedelta(days=1)).strftime('%Y-%m-%dT00:00:00') }}"
+        end_date_time: "{{ (now() + timedelta(days=1)).strftime('%Y-%m-%dT23:59:59') }}"
+      response_variable: result
+  speech:
+    text: >-
+      {% set events = result['calendar.family']['events'] %}
+      {% if events | length == 0 %}
+        Nothing on the calendar tomorrow.
+      {% else %}
+        Tomorrow you have {{ events | length }} event{{ 's' if events | length > 1 else '' }}:
+        {% for e in events %}
+          {{ e.summary }}{% if not loop.last %}, {% endif %}
+        {% endfor %}.
+      {% endif %}
+
+# ── Navigation ──────────────────────────────────────────────────
+# Fires an event that the Beacon SPA can listen for via the HA WebSocket.
+# The SPA should handle `beacon_navigate` events to switch views.
+BeaconShowView:
+  action:
+    - event: beacon_navigate
+      event_data:
+        view: "{{ view | lower }}"
+  speech:
+    text: "Switching to {{ view }}."
+
+# ── Timer ───────────────────────────────────────────────────────
+# Uses HA's built-in timer helper. Requires a timer.beacon_voice entity.
+# Create it in Settings > Devices & Services > Helpers > Timer.
+BeaconSetTimer:
+  action:
+    - service: timer.start
+      target:
+        entity_id: "timer.beacon_voice"
+      data:
+        duration: "{{ duration }}"
+  speech:
+    text: "Timer set for {{ duration }}."
+
+# ── Quick Status ────────────────────────────────────────────────
+BeaconGroceryList:
+  action:
+    - service: todo.get_items
+      target:
+        entity_id: "todo.grocery"
+      data:
+        status: "needs_action"
+      response_variable: result
+  speech:
+    text: >-
+      {% set items = result['todo.grocery']['items'] %}
+      {% if items | length == 0 %}
+        The grocery list is empty.
+      {% else %}
+        You have {{ items | length }} item{{ 's' if items | length > 1 else '' }} on the grocery list:
+        {% for i in items %}
+          {{ i.summary }}{% if not loop.last %}, {% endif %}
+        {% endfor %}.
+      {% endif %}
+
+BeaconChoreStatus:
+  action:
+    - service: todo.get_items
+      target:
+        entity_id: "todo.chores"
+      data:
+        status: "needs_action"
+      response_variable: result
+  speech:
+    text: >-
+      {% set items = result['todo.chores']['items'] %}
+      {% if items | length == 0 %}
+        All chores are done!
+      {% else %}
+        {{ items | length }} chore{{ 's' if items | length > 1 else '' }} left:
+        {% for i in items %}
+          {{ i.summary }}{% if not loop.last %}, {% endif %}
+        {% endfor %}.
+      {% endif %}

--- a/custom_sentences/en/beacon.yaml
+++ b/custom_sentences/en/beacon.yaml
@@ -1,0 +1,119 @@
+language: en
+intents:
+  # ── List Management ──────────────────────────────────────────────
+  BeaconAddItem:
+    data:
+      - sentences:
+          - "add {item} to [the] {list_name} list"
+          - "put {item} on [the] {list_name} list"
+          - "add {item} to [the] {list_name}"
+          - "put {item} on [the] {list_name}"
+        requires_context:
+          domain: todo
+        slots:
+          item:
+            type: text
+          list_name:
+            type: text
+
+  # ── Chore Tracking ──────────────────────────────────────────────
+  BeaconCompleteChore:
+    data:
+      - sentences:
+          - "mark {chore} as done"
+          - "mark {chore} as complete"
+          - "complete [the] {chore} chore"
+          - "{chore} is done"
+          - "I finished {chore}"
+          - "finished {chore}"
+        slots:
+          chore:
+            type: text
+
+  BeaconCompleteChoreByPerson:
+    data:
+      - sentences:
+          - "{name} finished {chore}"
+          - "{name} completed {chore}"
+          - "{name} did {chore}"
+          - "{name} did [the] {chore} chore"
+        slots:
+          name:
+            type: text
+          chore:
+            type: text
+
+  # ── Calendar ────────────────────────────────────────────────────
+  BeaconCalendarToday:
+    data:
+      - sentences:
+          - "what's on the calendar today"
+          - "what is on the calendar today"
+          - "what's on the calendar"
+          - "what is on the calendar"
+          - "show today's calendar"
+          - "what's happening today"
+          - "what do we have today"
+          - "any events today"
+          - "what's on the schedule"
+          - "what is on the schedule"
+
+  BeaconCalendarTomorrow:
+    data:
+      - sentences:
+          - "what's on the calendar tomorrow"
+          - "what is on the calendar tomorrow"
+          - "what's happening tomorrow"
+          - "any events tomorrow"
+          - "what do we have tomorrow"
+
+  # ── Navigation ──────────────────────────────────────────────────
+  BeaconShowView:
+    data:
+      - sentences:
+          - "show [the] {view}"
+          - "switch to [the] {view}"
+          - "open [the] {view}"
+          - "go to [the] {view}"
+          - "navigate to [the] {view}"
+          - "show [the] {view} view"
+          - "switch to [the] {view} view"
+          - "open [the] {view} view"
+          - "show [the] {view} screen"
+          - "show [the] {view} page"
+        slots:
+          view:
+            type: text
+
+  # ── Timer ───────────────────────────────────────────────────────
+  BeaconSetTimer:
+    data:
+      - sentences:
+          - "set a timer for {duration}"
+          - "set a {duration} timer"
+          - "start a timer for {duration}"
+          - "start a {duration} timer"
+          - "timer for {duration}"
+          - "set [a] {duration} countdown"
+        slots:
+          duration:
+            type: text
+
+  # ── Quick Status ────────────────────────────────────────────────
+  BeaconGroceryList:
+    data:
+      - sentences:
+          - "what's on the grocery list"
+          - "what is on the grocery list"
+          - "what do we need from the store"
+          - "read the grocery list"
+          - "what groceries do we need"
+
+  BeaconChoreStatus:
+    data:
+      - sentences:
+          - "what chores are left"
+          - "what chores need to be done"
+          - "any chores left"
+          - "show the chore list"
+          - "what needs to be done"


### PR DESCRIPTION
Once #8/#9 actually got the release → build-addon trigger chain working, the Docker build itself failed for the first time in months:

\`\`\`
ERROR: failed to calculate checksum of ref ...: "/custom_intents": not found
ERROR: failed to calculate checksum of ref ...: "/custom_sentences": not found
\`\`\`

**Root cause:** the Dockerfile \`COPY\`s \`custom_intents/\` and \`custom_sentences/\`, and \`build-addon.yml\` builds with \`context: .\` (repo root) — but both directories only ever existed under \`beacon/\`, never at the repo root. This has apparently been broken since whenever those HA voice-assistant intent/sentence files were added; it just never surfaced because the image build hasn't actually executed since ~March (the exact gap #8/#9 just closed).

**Fix:** mirror \`beacon/custom_intents/\` and \`beacon/custom_sentences/\` to the repo root, matching the existing sync pattern for \`Dockerfile\`/\`run.sh\`/\`CHANGELOG.md\`. Updated \`CLAUDE.md\`'s dual-directory notes to call this out so future root-level Dockerfile dependencies get synced the same way.

No app source changes — CI/build-context only. Verified: \`npm test\` (32/32), directory content diff-confirmed identical to \`beacon/\`.