### PR TITLE
fix(ci): build-addon.yml was tagging the wrong (pre-bump) version

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -20,7 +20,29 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout
+      # actions/checkout@v4 defaults to github.sha, which is PINNED to
+      # whatever commit triggered this workflow run. When invoked via
+      # workflow_call right after the `release` job, semantic-release has
+      # already pushed a NEW commit (the version bump to config.yaml) --
+      # but that new commit is invisible to this checkout unless we
+      # explicitly ask for the branch HEAD instead of the frozen sha.
+      # Without this, the image gets built one version behind every time
+      # (confirmed: v1.32.3's release run built and tagged the image as
+      # 1.32.2, the pre-bump version, because of exactly this).
+      #
+      # github.ref_name is 'main' for the workflow_call path (the caller was
+      # triggered by a push to main) and a tag name (e.g. 'v1.32.3') for the
+      # legacy manual release/push-tag path -- so it reliably distinguishes
+      # the two cases without relying on github.event_name, which doesn't
+      # behave as expected inside a called reusable workflow (see PR #9).
+      - name: Checkout (post-release main HEAD)
+        if: github.ref_name == 'main'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Checkout (manual release/tag)
+        if: github.ref_name != 'main'
         uses: actions/checkout@v4
 
       # release/push-tag triggers (e.g. a manually-created tag/release) may


### PR DESCRIPTION
The GHCR push permission issue is fixed (thanks!) and the image build succeeded for the first time — but it tagged the wrong version. v1.32.3's release run built and pushed the image as \`1.32.2\`, one version behind.

**Root cause:** \`actions/checkout@v4\` defaults to \`github.sha\`, pinned to whatever commit triggered the run. When \`build-addon.yml\` runs via \`workflow_call\` right after the \`release\` job, semantic-release has already pushed a new commit to \`main\` (the config.yaml version bump) — but that commit is invisible to the checkout unless \`main\`'s current HEAD is explicitly requested. So the build was always reading the pre-bump \`config.yaml\`.

**Fix:** explicitly checkout \`ref: main\` when \`github.ref_name == 'main'\` (the workflow_call path), falling back to the default sha-pinned checkout for the legacy manual release/tag path.

Verified: \`npm test\` (32/32), \`tsc --noEmit\` clean. Once merged I'll re-trigger the build for v1.32.3 to confirm the image gets tagged correctly this time.