### PR TITLE
fix(build): exclude test files from production tsc build

### DIFF
--- a/beacon/tsconfig.json
+++ b/beacon/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test/**"]
 }


### PR DESCRIPTION
Fixes the v1.32.4 add-on install failure.

Root cause: npm run build (tsc && vite build) was type-checking test files under src/ (*.test.ts, *.test.tsx) that reference vitest / @testing-library/react types not resolvable in the Docker build context, so tsc exits 2 and the Supervisor add-on build fails:

  error TS2307: Cannot find module 'vitest' or its corresponding type declarations.
  RUN npm run build did not complete successfully: exit code: 2

Confirmed via SSH into the HA host + ha supervisor logs. This has never been a GHCR-visibility issue (previously suspected) -- Beacon builds locally on-host from beacon/Dockerfile, no prebuilt image is pulled.

Fix: added exclude to both tsconfig.json and beacon/tsconfig.json (kept in sync per project convention) so the production tsc pass skips test files. Vitest's own runner is unaffected.

Verified: npm run build succeeds locally after the fix (2144 modules transformed, dist/ produced).