### PR TITLE
Fix hidden calendars in dashboard and sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,6 +138,11 @@ export function App() {
   useEffect(() => {
     setHiddenCalendars(new Set(settings.permanentlyHiddenCalendars));
   }, [settings.permanentlyHiddenCalendars]);
+
+  const visibleEvents = useMemo(
+    () => events.filter((event) => !hiddenCalendars.has(event.calendarId)),
+    [events, hiddenCalendars],
+  );
   const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
   const [showModal, setShowModal] = useState(false);
   const [prefillDate, setPrefillDate] = useState<string | null>(null);
@@ -549,7 +554,7 @@ export function App() {
         {activeView === 'dashboard' ? (
           <>
             <DashboardView
-              events={events}
+              events={visibleEvents}
               weather={weather}
               chores={settings.choresEnabled ? chores : []}
               completedChoreIds={completedChoreIds}
@@ -668,7 +673,7 @@ export function App() {
                 />
               </div>
               <CalendarSidebar
-                events={events}
+                events={visibleEvents}
                 chores={settings.choresEnabled ? chores : []}
                 completedChoreIds={completedChoreIds}
                 onToggleChore={handleToggleChore}


### PR DESCRIPTION
## Summary

Fixes hidden calendars still appearing in the Dashboard and Calendar sidebar.

## Problem

Calendar visibility settings were correctly applied by `WeekCalendar`, but `DashboardView` and `CalendarSidebar` were receiving the unfiltered `events` array.

As a result, calendars marked as hidden could still appear in the Dashboard's Today/Week sections and the Calendar sidebar.

## Fix

Create a shared `visibleEvents` array in `App.tsx` based on `hiddenCalendars`, then pass it to:

- `DashboardView`
- `CalendarSidebar`

`WeekCalendar` is left unchanged because it already handles hidden-calendar filtering internally.

## Testing

Tested with multiple Home Assistant calendar entities, including calendars configured as permanently hidden.

Verified that hidden calendar events no longer appear in:

- Dashboard Today
- Dashboard Week
- Calendar sidebar

Visible calendar events continue to display normally.