### PR TITLE
Added user support for taskmate

### DIFF
--- a/beacon/src/App.tsx
+++ b/beacon/src/App.tsx
@@ -559,6 +559,7 @@ export function App() {
               onWeatherClick={() => setActiveView('weather')}
               onEventClick={handleEventClick}
               members={members}
+              taskmateUsers={dashboardTasks.users}
               layout={settings.dashboardLayout}
             />
             <OmniAdd

--- a/beacon/src/components/DashboardView.tsx
+++ b/beacon/src/components/DashboardView.tsx
@@ -1,13 +1,14 @@
 import { useState, useEffect, useMemo } from 'react';
 import { format, parseISO, isSameDay, startOfDay, addDays } from 'date-fns';
 import { CalendarEvent, WeatherData } from '../types';
-import { Chore, FamilyMember } from '../types/family';
+import { Chore, FamilyMember, MEMBER_COLORS } from '../types/family';
 import { weatherIcon, conditionLabel } from '../types/weather-icons';
 import { EventCard } from './EventCard';
 import { TaskChecklist } from './TaskChecklist';
 import { useFamilyEvents } from '../hooks/useFamilyEvents';
 import { useMealPlans } from '../hooks/useMealPlans';
 import { MealType } from '../types/meals';
+import type { TaskmateUser } from '../types/taskmate';
 
 const MEAL_ICONS: Record<MealType, string> = {
   Breakfast: '🌅',
@@ -20,6 +21,8 @@ export interface TodoItem {
   uid: string;
   summary: string;
   status: 'needs_action' | 'completed';
+  userId?: string;
+  listId?: string;
 }
 
 interface DashboardViewProps {
@@ -29,10 +32,11 @@ interface DashboardViewProps {
   completedChoreIds: Set<string>;
   onToggleChore: (choreId: string) => void;
   todoItems?: TodoItem[];
-  onToggleTodo?: (uid: string, currentStatus: string) => void;
+  onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
   onWeatherClick?: () => void;
   onEventClick?: (event: CalendarEvent) => void;
   members?: FamilyMember[];
+  taskmateUsers?: TaskmateUser[];
   layout?: 'default' | 'classic' | 'compact';
 }
 
@@ -47,6 +51,7 @@ export function DashboardView({
   onWeatherClick,
   onEventClick,
   members = [],
+  taskmateUsers = [],
   layout = 'default',
 }: DashboardViewProps) {
   const [now, setNow] = useState(new Date());
@@ -141,24 +146,15 @@ export function DashboardView({
         {(() => {
           const pending = todoItems.filter((t) => t.status === 'needs_action');
           if (todoItems.length > 0) {
-            return pending.length > 0 ? (
-              <ul className="task-checklist">
-                {pending.map((item) => (
-                  <li key={item.uid} className="task-checklist-item">
-                    <button
-                      type="button"
-                      className="task-checkbox"
-                      onClick={() => onToggleTodo?.(item.uid, item.status)}
-                      aria-label={`Complete ${item.summary}`}
-                    >
-                      <span className="task-checkbox-box" />
-                    </button>
-                    <span className="task-checklist-label">{item.summary}</span>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <div className="task-checklist-done">All done!</div>
+            if (pending.length === 0) {
+              return <div className="task-checklist-done">All done!</div>;
+            }
+            return (
+              <TaskGroups
+                items={pending}
+                users={taskmateUsers}
+                onToggleTodo={onToggleTodo}
+              />
             );
           }
           return (
@@ -305,6 +301,95 @@ export function DashboardView({
       <aside className="dash-sidebar">
         {sidebarSections}
       </aside>
+    </div>
+  );
+}
+
+function TaskRow({
+  item,
+  onToggleTodo,
+}: {
+  item: TodoItem;
+  onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
+}) {
+  return (
+    <li key={`${item.listId ?? 'local'}:${item.uid}`} className="task-checklist-item">
+      <button
+        type="button"
+        className="task-checkbox"
+        onClick={() => onToggleTodo?.(item.uid, item.status, item.listId)}
+        aria-label={`Complete ${item.summary}`}
+      >
+        <span className="task-checkbox-box" />
+      </button>
+      <span className="task-checklist-label">{item.summary}</span>
+    </li>
+  );
+}
+
+interface TaskGroup {
+  key: string;
+  label: string;
+  color?: string;
+  items: TodoItem[];
+}
+
+function TaskGroups({
+  items,
+  users,
+  onToggleTodo,
+}: {
+  items: TodoItem[];
+  users: TaskmateUser[];
+  onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
+}) {
+  if (users.length === 0) {
+    return (
+      <ul className="task-checklist">
+        {items.map((item) => (
+          <TaskRow key={`${item.listId ?? 'local'}:${item.uid}`} item={item} onToggleTodo={onToggleTodo} />
+        ))}
+      </ul>
+    );
+  }
+
+  const groups: TaskGroup[] = users.map(
+    (u, i) => ({ key: u.childId, label: u.name, color: MEMBER_COLORS[i % MEMBER_COLORS.length], items: [] }),
+  );
+  const shared: TaskGroup = { key: '__shared', label: 'Shared', items: [] };
+
+  for (const item of items) {
+    const bucket = item.userId ? groups.find((g) => g.key === item.userId) : undefined;
+    (bucket ?? shared).items.push(item);
+  }
+
+  const visible = [
+    ...groups.filter((g) => g.items.length > 0),
+    ...(shared.items.length > 0 ? [shared] : []),
+  ];
+
+  return (
+    <div className="task-groups">
+      {visible.map((group) => (
+        <div key={group.key} className="task-group">
+          <div className="task-group-header">
+            <span
+              className="task-group-avatar"
+              style={group.color ? { backgroundColor: group.color + '22', borderColor: group.color } : undefined}
+            >
+              {group.label.charAt(0).toUpperCase()}
+            </span>
+            <span className="task-group-name" style={group.color ? { color: group.color } : undefined}>
+              {group.label}
+            </span>
+          </div>
+          <ul className="task-checklist">
+            {group.items.map((item) => (
+              <TaskRow item={item} onToggleTodo={onToggleTodo} />
+            ))}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 }

--- a/beacon/src/components/DashboardView.tsx
+++ b/beacon/src/components/DashboardView.tsx
@@ -144,14 +144,10 @@ export function DashboardView({
       <section className="dash-sidebar-section">
         <h3 className="dash-sidebar-heading">Tasks</h3>
         {(() => {
-          const pending = todoItems.filter((t) => t.status === 'needs_action');
           if (todoItems.length > 0) {
-            if (pending.length === 0) {
-              return <div className="task-checklist-done">All done!</div>;
-            }
             return (
               <TaskGroups
-                items={pending}
+                items={todoItems}
                 users={taskmateUsers}
                 onToggleTodo={onToggleTodo}
               />
@@ -312,17 +308,25 @@ function TaskRow({
   item: TodoItem;
   onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
 }) {
+  const done = item.status === 'completed';
   return (
-    <li key={`${item.listId ?? 'local'}:${item.uid}`} className="task-checklist-item">
+    <li className={`task-checklist-item${done ? ' task-checklist-item--done' : ''}`}>
       <button
         type="button"
-        className="task-checkbox"
+        className={`task-checkbox${done ? ' task-checkbox--checked' : ''}`}
+        disabled={done}
         onClick={() => onToggleTodo?.(item.uid, item.status, item.listId)}
-        aria-label={`Complete ${item.summary}`}
+        aria-label={done ? `Completed ${item.summary}` : `Complete ${item.summary}`}
       >
-        <span className="task-checkbox-box" />
+        <span className="task-checkbox-box">
+          {done && (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          )}
+        </span>
       </button>
-      <span className="task-checklist-label">{item.summary}</span>
+      <span className={`task-checklist-label${done ? ' task-checklist-label--done' : ''}`}>{item.summary}</span>
     </li>
   );
 }
@@ -343,10 +347,14 @@ function TaskGroups({
   users: TaskmateUser[];
   onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
 }) {
+  const sorted = [...items].sort(
+    (a, b) => (a.status === 'completed' ? 1 : 0) - (b.status === 'completed' ? 1 : 0),
+  );
+
   if (users.length === 0) {
     return (
       <ul className="task-checklist">
-        {items.map((item) => (
+        {sorted.map((item) => (
           <TaskRow key={`${item.listId ?? 'local'}:${item.uid}`} item={item} onToggleTodo={onToggleTodo} />
         ))}
       </ul>
@@ -358,7 +366,7 @@ function TaskGroups({
   );
   const shared: TaskGroup = { key: '__shared', label: 'Shared', items: [] };
 
-  for (const item of items) {
+  for (const item of sorted) {
     const bucket = item.userId ? groups.find((g) => g.key === item.userId) : undefined;
     (bucket ?? shared).items.push(item);
   }
@@ -385,7 +393,7 @@ function TaskGroups({
           </div>
           <ul className="task-checklist">
             {group.items.map((item) => (
-              <TaskRow item={item} onToggleTodo={onToggleTodo} />
+              <TaskRow key={`${item.listId ?? 'local'}:${item.uid}`} item={item} onToggleTodo={onToggleTodo} />
             ))}
           </ul>
         </div>

--- a/beacon/src/hooks/useDashboardTasks.ts
+++ b/beacon/src/hooks/useDashboardTasks.ts
@@ -13,7 +13,7 @@ export interface DashboardTodoItem {
 
 export function useDashboardTasks(connected: boolean) {
   const localTasks = useLocalTasks();
-  const { users, listByUser } = useTaskmate(connected);
+  const { users, listByUser, completions } = useTaskmate(connected);
   const [haItems, setHaItems] = useState<Omit<DashboardTodoItem, 'userId'>[]>([]);
 
   // Fetch HA todo items for task-type lists
@@ -65,18 +65,38 @@ export function useDashboardTasks(connected: boolean) {
   const items: DashboardTodoItem[] = useMemo(() => {
     const local: DashboardTodoItem[] = localTasks
       .getTasksForList('beacon-todo')
+      .filter(t => t.status === 'needs_action' || (t.completedAt ? isToday(t.completedAt) : false))
       .map(t => ({
         uid: t.id,
         summary: t.summary,
         status: t.status,
         listId: 'beacon-todo',
       }));
-    const fromHa: DashboardTodoItem[] = haItems.map(i => ({
-      ...i,
-      userId: listByUser[i.listId]?.childId,
+
+    const fromHa: DashboardTodoItem[] = [];
+    for (const i of haItems) {
+      const userId = listByUser[i.listId]?.childId;
+      if (i.status === 'needs_action' || userId != null) {
+        fromHa.push({ ...i, userId });
+      }
+    }
+
+    const done: DashboardTodoItem[] = completions.map(c => ({
+      uid: c.uid,
+      summary: c.summary,
+      status: 'completed' as const,
+      listId: '',
+      userId: c.userId,
     }));
-    return [...local, ...fromHa];
-  }, [localTasks, haItems, listByUser]);
+
+    const seen = new Set<string>();
+    return [...local, ...fromHa, ...done].filter(it => {
+      const key = `${it.userId ?? ''}:${it.uid}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [localTasks, haItems, listByUser, completions]);
 
   const toggleItem = useCallback(async (uid: string, currentStatus: string, listId?: string) => {
     // Check if it's a local item
@@ -117,4 +137,14 @@ const GROCERY_KEYWORDS = [
 function isGroceryEntity(name: string): boolean {
   const lower = name.toLowerCase();
   return GROCERY_KEYWORDS.some(kw => lower.includes(kw));
+}
+
+function isToday(iso: string): boolean {
+  const d = new Date(iso);
+  const now = new Date();
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
 }

--- a/beacon/src/hooks/useDashboardTasks.ts
+++ b/beacon/src/hooks/useDashboardTasks.ts
@@ -1,21 +1,20 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { hasToken, haFetch, callHaService } from '../api/ha-rest';
 import { useLocalTasks } from './useLocalTasks';
+import { useTaskmate } from './useTaskmate';
 
 export interface DashboardTodoItem {
   uid: string;
   summary: string;
   status: 'needs_action' | 'completed';
   listId: string;
+  userId?: string;
 }
 
-/**
- * Fetches todo items for the dashboard Tasks section.
- * Combines local To-Do items with items from the first HA task-type list.
- */
 export function useDashboardTasks(connected: boolean) {
   const localTasks = useLocalTasks();
-  const [haItems, setHaItems] = useState<DashboardTodoItem[]>([]);
+  const { users, listByUser } = useTaskmate(connected);
+  const [haItems, setHaItems] = useState<Omit<DashboardTodoItem, 'userId'>[]>([]);
 
   // Fetch HA todo items for task-type lists
   useEffect(() => {
@@ -23,7 +22,7 @@ export function useDashboardTasks(connected: boolean) {
 
     async function fetchTasks() {
       try {
-        // Get the first non-grocery HA todo entity
+        // Get the non-grocery HA todo entities
         const states = await haFetch('/api/states') as Array<{ entity_id: string; state: string; attributes: Record<string, unknown> }>;
 
         const todoEntities = states.filter(s =>
@@ -33,7 +32,7 @@ export function useDashboardTasks(connected: boolean) {
         );
 
         // Fetch items from up to 3 task lists
-        const items: DashboardTodoItem[] = [];
+        const items: Omit<DashboardTodoItem, 'userId'>[] = [];
         for (const entity of todoEntities.slice(0, 3)) {
           try {
             const result = await callHaService('todo', 'get_items', {
@@ -63,19 +62,23 @@ export function useDashboardTasks(connected: boolean) {
     return () => clearInterval(interval);
   }, [connected]);
 
-  // Combine local To-Do items + HA task items
-  const localItems: DashboardTodoItem[] = localTasks
-    .getTasksForList('beacon-todo')
-    .map(t => ({
-      uid: t.id,
-      summary: t.summary,
-      status: t.status,
-      listId: 'beacon-todo',
+  const items: DashboardTodoItem[] = useMemo(() => {
+    const local: DashboardTodoItem[] = localTasks
+      .getTasksForList('beacon-todo')
+      .map(t => ({
+        uid: t.id,
+        summary: t.summary,
+        status: t.status,
+        listId: 'beacon-todo',
+      }));
+    const fromHa: DashboardTodoItem[] = haItems.map(i => ({
+      ...i,
+      userId: listByUser[i.listId]?.childId,
     }));
+    return [...local, ...fromHa];
+  }, [localTasks, haItems, listByUser]);
 
-  const allItems = [...localItems, ...haItems];
-
-  const toggleItem = useCallback(async (uid: string, currentStatus: string) => {
+  const toggleItem = useCallback(async (uid: string, currentStatus: string, listId?: string) => {
     // Check if it's a local item
     const localItem = localTasks.getTasksForList('beacon-todo').find(t => t.id === uid);
     if (localItem) {
@@ -83,8 +86,8 @@ export function useDashboardTasks(connected: boolean) {
       return;
     }
 
-    // HA item — find the list and toggle
-    const haItem = haItems.find(i => i.uid === uid);
+    const haItem = haItems.find(i => i.uid === uid && (listId == null || i.listId === listId))
+      ?? haItems.find(i => i.uid === uid);
     if (!haItem) return;
     const newStatus = currentStatus === 'needs_action' ? 'completed' : 'needs_action';
     try {
@@ -94,14 +97,16 @@ export function useDashboardTasks(connected: boolean) {
         status: newStatus,
       });
       setHaItems(prev => prev.map(i =>
-        i.uid === uid ? { ...i, status: newStatus as 'needs_action' | 'completed' } : i
+        i.uid === uid && i.listId === haItem.listId
+          ? { ...i, status: newStatus as 'needs_action' | 'completed' }
+          : i
       ));
     } catch (err) {
       console.warn('Failed to toggle todo item:', err);
     }
   }, [localTasks, haItems]);
 
-  return { items: allItems, toggleItem };
+  return { items, toggleItem, users };
 }
 
 const GROCERY_KEYWORDS = [

--- a/beacon/src/hooks/useLocalTasks.ts
+++ b/beacon/src/hooks/useLocalTasks.ts
@@ -12,6 +12,7 @@ export interface LocalTask {
   status: 'needs_action' | 'completed';
   listId: string;
   createdAt: string;
+  completedAt?: string;
 }
 
 export interface LocalTaskList {
@@ -66,7 +67,9 @@ export function useLocalTasks() {
   const toggleTask = useCallback((taskId: string) => {
     setTasks(prev => prev.map(t =>
       t.id === taskId
-        ? { ...t, status: t.status === 'needs_action' ? 'completed' : 'needs_action' }
+        ? t.status === 'needs_action'
+          ? { ...t, status: 'completed', completedAt: new Date().toISOString() }
+          : { ...t, status: 'needs_action', completedAt: undefined }
         : t
     ));
   }, []);

--- a/beacon/src/hooks/useTaskmate.ts
+++ b/beacon/src/hooks/useTaskmate.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect } from 'react';
+import { haFetch, hasToken } from '../api/ha-rest';
+import { TaskmateUser } from '../types/taskmate';
+
+interface HaState {
+  entity_id: string;
+  state: string;
+  attributes: Record<string, unknown>;
+}
+
+interface OverviewChild {
+  id: string;
+  name: string;
+}
+
+export interface UseTaskmateResult {
+  users: TaskmateUser[];
+  listByUser: Record<string, TaskmateUser>;
+}
+
+function findOverview(states: HaState[]): HaState | undefined {
+  return states.find(
+    (s) =>
+      s.entity_id.startsWith('sensor.') &&
+      s.entity_id.endsWith('_overview') &&
+      Array.isArray(s.attributes.children),
+  );
+}
+
+export function useTaskmate(connected: boolean): UseTaskmateResult {
+  const [users, setUsers] = useState<TaskmateUser[]>([]);
+
+  useEffect(() => {
+    if (!connected && !hasToken()) return;
+
+    async function fetchTaskmate() {
+      try {
+        const states = (await haFetch('/api/states')) as HaState[];
+        const byEntity = new Map(states.map((s) => [s.entity_id, s]));
+
+        const overview = findOverview(states);
+        if (!overview) {
+          setUsers([]);
+          return;
+        }
+
+        const byChildId = new Map(
+          ((overview.attributes.children as OverviewChild[]) ?? []).map((c) => [c.id, c]),
+        );
+
+        const resolved: TaskmateUser[] = [];
+        const seen = new Set<string>();
+
+        for (const s of states) {
+          if (!s.entity_id.startsWith('todo.') || s.state === 'unavailable') continue;
+          const stats = byEntity.get(`sensor.${s.entity_id.slice('todo.'.length)}_stats`);
+          const childId = stats ? (stats.attributes.child_id as string | undefined) : undefined;
+          const child = childId ? byChildId.get(childId) : undefined;
+          if (!child || seen.has(child.id)) continue;
+          seen.add(child.id);
+
+          resolved.push({ childId: child.id, name: child.name, todoListId: s.entity_id });
+        }
+
+        resolved.sort((a, b) => a.name.localeCompare(b.name));
+        setUsers(resolved);
+      } catch (err) {
+        console.warn('Failed to fetch TaskMate users:', err);
+      }
+    }
+
+    fetchTaskmate();
+    const interval = setInterval(fetchTaskmate, 60_000);
+    return () => clearInterval(interval);
+  }, [connected]);
+
+  const listByUser: Record<string, TaskmateUser> = {};
+  for (const u of users) listByUser[u.todoListId] = u;
+
+  return { users, listByUser };
+}

--- a/beacon/src/hooks/useTaskmate.ts
+++ b/beacon/src/hooks/useTaskmate.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { haFetch, hasToken } from '../api/ha-rest';
-import { TaskmateUser } from '../types/taskmate';
+import { TaskmateUser, TaskmateCompletion } from '../types/taskmate';
 
 interface HaState {
   entity_id: string;
@@ -13,9 +13,17 @@ interface OverviewChild {
   name: string;
 }
 
+interface CompletionRaw {
+  chore_id?: string;
+  child_id?: string;
+  chore_name?: string;
+  completed_at?: string;
+}
+
 export interface UseTaskmateResult {
   users: TaskmateUser[];
   listByUser: Record<string, TaskmateUser>;
+  completions: TaskmateCompletion[];
 }
 
 function findOverview(states: HaState[]): HaState | undefined {
@@ -29,6 +37,7 @@ function findOverview(states: HaState[]): HaState | undefined {
 
 export function useTaskmate(connected: boolean): UseTaskmateResult {
   const [users, setUsers] = useState<TaskmateUser[]>([]);
+  const [completions, setCompletions] = useState<TaskmateCompletion[]>([]);
 
   useEffect(() => {
     if (!connected && !hasToken()) return;
@@ -41,6 +50,7 @@ export function useTaskmate(connected: boolean): UseTaskmateResult {
         const overview = findOverview(states);
         if (!overview) {
           setUsers([]);
+          setCompletions([]);
           return;
         }
 
@@ -64,6 +74,24 @@ export function useTaskmate(connected: boolean): UseTaskmateResult {
 
         resolved.sort((a, b) => a.name.localeCompare(b.name));
         setUsers(resolved);
+
+        const choresSensor = states.find((s) => Array.isArray(s.attributes.todays_completions));
+        const raw = (choresSensor?.attributes.todays_completions as CompletionRaw[] | undefined) ?? [];
+        const seenComp = new Set<string>();
+        const done: TaskmateCompletion[] = [];
+        for (const c of raw) {
+          if (!c.chore_id || !c.child_id) continue;
+          const key = `${c.child_id}:${c.chore_id}`;
+          if (seenComp.has(key)) continue;
+          seenComp.add(key);
+          done.push({
+            uid: c.chore_id,
+            summary: c.chore_name ?? '',
+            userId: c.child_id,
+            completedAt: c.completed_at ?? '',
+          });
+        }
+        setCompletions(done);
       } catch (err) {
         console.warn('Failed to fetch TaskMate users:', err);
       }
@@ -77,5 +105,5 @@ export function useTaskmate(connected: boolean): UseTaskmateResult {
   const listByUser: Record<string, TaskmateUser> = {};
   for (const u of users) listByUser[u.todoListId] = u;
 
-  return { users, listByUser };
+  return { users, listByUser, completions };
 }

--- a/beacon/src/styles/dashboard.css
+++ b/beacon/src/styles/dashboard.css
@@ -567,6 +567,41 @@
   font-weight: 500;
 }
 
+.task-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.task-group { display: flex; flex-direction: column; gap: 4px; }
+
+.task-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 4px 2px;
+}
+
+.task-group-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1.5px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.task-group-name { font-size: 0.8rem; font-weight: 700; }
+
+.task-groups .task-checklist { flex: none; overflow-y: visible; }
+
 /* ─── Responsive: Tablet < 768px ─── */
 @media (max-width: 768px) {
   .dashboard {

--- a/beacon/src/types/taskmate.ts
+++ b/beacon/src/types/taskmate.ts
@@ -1,0 +1,5 @@
+export interface TaskmateUser {
+  childId: string;
+  name: string;
+  todoListId: string;
+}

--- a/beacon/src/types/taskmate.ts
+++ b/beacon/src/types/taskmate.ts
@@ -3,3 +3,10 @@ export interface TaskmateUser {
   name: string;
   todoListId: string;
 }
+
+export interface TaskmateCompletion {
+  uid: string;
+  summary: string;
+  userId: string;
+  completedAt: string;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -559,6 +559,7 @@ export function App() {
               onWeatherClick={() => setActiveView('weather')}
               onEventClick={handleEventClick}
               members={members}
+              taskmateUsers={dashboardTasks.users}
               layout={settings.dashboardLayout}
             />
             <OmniAdd

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -1,13 +1,14 @@
 import { useState, useEffect, useMemo } from 'react';
 import { format, parseISO, isSameDay, startOfDay, addDays } from 'date-fns';
 import { CalendarEvent, WeatherData } from '../types';
-import { Chore, FamilyMember } from '../types/family';
+import { Chore, FamilyMember, MEMBER_COLORS } from '../types/family';
 import { weatherIcon, conditionLabel } from '../types/weather-icons';
 import { EventCard } from './EventCard';
 import { TaskChecklist } from './TaskChecklist';
 import { useFamilyEvents } from '../hooks/useFamilyEvents';
 import { useMealPlans } from '../hooks/useMealPlans';
 import { MealType } from '../types/meals';
+import type { TaskmateUser } from '../types/taskmate';
 
 const MEAL_ICONS: Record<MealType, string> = {
   Breakfast: '🌅',
@@ -20,6 +21,8 @@ export interface TodoItem {
   uid: string;
   summary: string;
   status: 'needs_action' | 'completed';
+  userId?: string;
+  listId?: string;
 }
 
 interface DashboardViewProps {
@@ -29,10 +32,11 @@ interface DashboardViewProps {
   completedChoreIds: Set<string>;
   onToggleChore: (choreId: string) => void;
   todoItems?: TodoItem[];
-  onToggleTodo?: (uid: string, currentStatus: string) => void;
+  onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
   onWeatherClick?: () => void;
   onEventClick?: (event: CalendarEvent) => void;
   members?: FamilyMember[];
+  taskmateUsers?: TaskmateUser[];
   layout?: 'default' | 'classic' | 'compact';
 }
 
@@ -47,6 +51,7 @@ export function DashboardView({
   onWeatherClick,
   onEventClick,
   members = [],
+  taskmateUsers = [],
   layout = 'default',
 }: DashboardViewProps) {
   const [now, setNow] = useState(new Date());
@@ -141,24 +146,15 @@ export function DashboardView({
         {(() => {
           const pending = todoItems.filter((t) => t.status === 'needs_action');
           if (todoItems.length > 0) {
-            return pending.length > 0 ? (
-              <ul className="task-checklist">
-                {pending.map((item) => (
-                  <li key={item.uid} className="task-checklist-item">
-                    <button
-                      type="button"
-                      className="task-checkbox"
-                      onClick={() => onToggleTodo?.(item.uid, item.status)}
-                      aria-label={`Complete ${item.summary}`}
-                    >
-                      <span className="task-checkbox-box" />
-                    </button>
-                    <span className="task-checklist-label">{item.summary}</span>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <div className="task-checklist-done">All done!</div>
+            if (pending.length === 0) {
+              return <div className="task-checklist-done">All done!</div>;
+            }
+            return (
+              <TaskGroups
+                items={pending}
+                users={taskmateUsers}
+                onToggleTodo={onToggleTodo}
+              />
             );
           }
           return (
@@ -305,6 +301,95 @@ export function DashboardView({
       <aside className="dash-sidebar">
         {sidebarSections}
       </aside>
+    </div>
+  );
+}
+
+function TaskRow({
+  item,
+  onToggleTodo,
+}: {
+  item: TodoItem;
+  onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
+}) {
+  return (
+    <li key={`${item.listId ?? 'local'}:${item.uid}`} className="task-checklist-item">
+      <button
+        type="button"
+        className="task-checkbox"
+        onClick={() => onToggleTodo?.(item.uid, item.status, item.listId)}
+        aria-label={`Complete ${item.summary}`}
+      >
+        <span className="task-checkbox-box" />
+      </button>
+      <span className="task-checklist-label">{item.summary}</span>
+    </li>
+  );
+}
+
+interface TaskGroup {
+  key: string;
+  label: string;
+  color?: string;
+  items: TodoItem[];
+}
+
+function TaskGroups({
+  items,
+  users,
+  onToggleTodo,
+}: {
+  items: TodoItem[];
+  users: TaskmateUser[];
+  onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
+}) {
+  if (users.length === 0) {
+    return (
+      <ul className="task-checklist">
+        {items.map((item) => (
+          <TaskRow key={`${item.listId ?? 'local'}:${item.uid}`} item={item} onToggleTodo={onToggleTodo} />
+        ))}
+      </ul>
+    );
+  }
+
+  const groups: TaskGroup[] = users.map(
+    (u, i) => ({ key: u.childId, label: u.name, color: MEMBER_COLORS[i % MEMBER_COLORS.length], items: [] }),
+  );
+  const shared: TaskGroup = { key: '__shared', label: 'Shared', items: [] };
+
+  for (const item of items) {
+    const bucket = item.userId ? groups.find((g) => g.key === item.userId) : undefined;
+    (bucket ?? shared).items.push(item);
+  }
+
+  const visible = [
+    ...groups.filter((g) => g.items.length > 0),
+    ...(shared.items.length > 0 ? [shared] : []),
+  ];
+
+  return (
+    <div className="task-groups">
+      {visible.map((group) => (
+        <div key={group.key} className="task-group">
+          <div className="task-group-header">
+            <span
+              className="task-group-avatar"
+              style={group.color ? { backgroundColor: group.color + '22', borderColor: group.color } : undefined}
+            >
+              {group.label.charAt(0).toUpperCase()}
+            </span>
+            <span className="task-group-name" style={group.color ? { color: group.color } : undefined}>
+              {group.label}
+            </span>
+          </div>
+          <ul className="task-checklist">
+            {group.items.map((item) => (
+              <TaskRow item={item} onToggleTodo={onToggleTodo} />
+            ))}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -144,14 +144,10 @@ export function DashboardView({
       <section className="dash-sidebar-section">
         <h3 className="dash-sidebar-heading">Tasks</h3>
         {(() => {
-          const pending = todoItems.filter((t) => t.status === 'needs_action');
           if (todoItems.length > 0) {
-            if (pending.length === 0) {
-              return <div className="task-checklist-done">All done!</div>;
-            }
             return (
               <TaskGroups
-                items={pending}
+                items={todoItems}
                 users={taskmateUsers}
                 onToggleTodo={onToggleTodo}
               />
@@ -312,17 +308,25 @@ function TaskRow({
   item: TodoItem;
   onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
 }) {
+  const done = item.status === 'completed';
   return (
-    <li key={`${item.listId ?? 'local'}:${item.uid}`} className="task-checklist-item">
+    <li className={`task-checklist-item${done ? ' task-checklist-item--done' : ''}`}>
       <button
         type="button"
-        className="task-checkbox"
+        className={`task-checkbox${done ? ' task-checkbox--checked' : ''}`}
+        disabled={done}
         onClick={() => onToggleTodo?.(item.uid, item.status, item.listId)}
-        aria-label={`Complete ${item.summary}`}
+        aria-label={done ? `Completed ${item.summary}` : `Complete ${item.summary}`}
       >
-        <span className="task-checkbox-box" />
+        <span className="task-checkbox-box">
+          {done && (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          )}
+        </span>
       </button>
-      <span className="task-checklist-label">{item.summary}</span>
+      <span className={`task-checklist-label${done ? ' task-checklist-label--done' : ''}`}>{item.summary}</span>
     </li>
   );
 }
@@ -343,10 +347,14 @@ function TaskGroups({
   users: TaskmateUser[];
   onToggleTodo?: (uid: string, currentStatus: string, listId?: string) => void;
 }) {
+  const sorted = [...items].sort(
+    (a, b) => (a.status === 'completed' ? 1 : 0) - (b.status === 'completed' ? 1 : 0),
+  );
+
   if (users.length === 0) {
     return (
       <ul className="task-checklist">
-        {items.map((item) => (
+        {sorted.map((item) => (
           <TaskRow key={`${item.listId ?? 'local'}:${item.uid}`} item={item} onToggleTodo={onToggleTodo} />
         ))}
       </ul>
@@ -358,7 +366,7 @@ function TaskGroups({
   );
   const shared: TaskGroup = { key: '__shared', label: 'Shared', items: [] };
 
-  for (const item of items) {
+  for (const item of sorted) {
     const bucket = item.userId ? groups.find((g) => g.key === item.userId) : undefined;
     (bucket ?? shared).items.push(item);
   }
@@ -385,7 +393,7 @@ function TaskGroups({
           </div>
           <ul className="task-checklist">
             {group.items.map((item) => (
-              <TaskRow item={item} onToggleTodo={onToggleTodo} />
+              <TaskRow key={`${item.listId ?? 'local'}:${item.uid}`} item={item} onToggleTodo={onToggleTodo} />
             ))}
           </ul>
         </div>

--- a/src/hooks/useDashboardTasks.ts
+++ b/src/hooks/useDashboardTasks.ts
@@ -13,7 +13,7 @@ export interface DashboardTodoItem {
 
 export function useDashboardTasks(connected: boolean) {
   const localTasks = useLocalTasks();
-  const { users, listByUser } = useTaskmate(connected);
+  const { users, listByUser, completions } = useTaskmate(connected);
   const [haItems, setHaItems] = useState<Omit<DashboardTodoItem, 'userId'>[]>([]);
 
   // Fetch HA todo items for task-type lists
@@ -65,18 +65,38 @@ export function useDashboardTasks(connected: boolean) {
   const items: DashboardTodoItem[] = useMemo(() => {
     const local: DashboardTodoItem[] = localTasks
       .getTasksForList('beacon-todo')
+      .filter(t => t.status === 'needs_action' || (t.completedAt ? isToday(t.completedAt) : false))
       .map(t => ({
         uid: t.id,
         summary: t.summary,
         status: t.status,
         listId: 'beacon-todo',
       }));
-    const fromHa: DashboardTodoItem[] = haItems.map(i => ({
-      ...i,
-      userId: listByUser[i.listId]?.childId,
+
+    const fromHa: DashboardTodoItem[] = [];
+    for (const i of haItems) {
+      const userId = listByUser[i.listId]?.childId;
+      if (i.status === 'needs_action' || userId != null) {
+        fromHa.push({ ...i, userId });
+      }
+    }
+
+    const done: DashboardTodoItem[] = completions.map(c => ({
+      uid: c.uid,
+      summary: c.summary,
+      status: 'completed' as const,
+      listId: '',
+      userId: c.userId,
     }));
-    return [...local, ...fromHa];
-  }, [localTasks, haItems, listByUser]);
+
+    const seen = new Set<string>();
+    return [...local, ...fromHa, ...done].filter(it => {
+      const key = `${it.userId ?? ''}:${it.uid}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [localTasks, haItems, listByUser, completions]);
 
   const toggleItem = useCallback(async (uid: string, currentStatus: string, listId?: string) => {
     // Check if it's a local item
@@ -117,4 +137,14 @@ const GROCERY_KEYWORDS = [
 function isGroceryEntity(name: string): boolean {
   const lower = name.toLowerCase();
   return GROCERY_KEYWORDS.some(kw => lower.includes(kw));
+}
+
+function isToday(iso: string): boolean {
+  const d = new Date(iso);
+  const now = new Date();
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
 }

--- a/src/hooks/useDashboardTasks.ts
+++ b/src/hooks/useDashboardTasks.ts
@@ -1,21 +1,20 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { hasToken, haFetch, callHaService } from '../api/ha-rest';
 import { useLocalTasks } from './useLocalTasks';
+import { useTaskmate } from './useTaskmate';
 
 export interface DashboardTodoItem {
   uid: string;
   summary: string;
   status: 'needs_action' | 'completed';
   listId: string;
+  userId?: string;
 }
 
-/**
- * Fetches todo items for the dashboard Tasks section.
- * Combines local To-Do items with items from the first HA task-type list.
- */
 export function useDashboardTasks(connected: boolean) {
   const localTasks = useLocalTasks();
-  const [haItems, setHaItems] = useState<DashboardTodoItem[]>([]);
+  const { users, listByUser } = useTaskmate(connected);
+  const [haItems, setHaItems] = useState<Omit<DashboardTodoItem, 'userId'>[]>([]);
 
   // Fetch HA todo items for task-type lists
   useEffect(() => {
@@ -23,7 +22,7 @@ export function useDashboardTasks(connected: boolean) {
 
     async function fetchTasks() {
       try {
-        // Get the first non-grocery HA todo entity
+        // Get the non-grocery HA todo entities
         const states = await haFetch('/api/states') as Array<{ entity_id: string; state: string; attributes: Record<string, unknown> }>;
 
         const todoEntities = states.filter(s =>
@@ -33,7 +32,7 @@ export function useDashboardTasks(connected: boolean) {
         );
 
         // Fetch items from up to 3 task lists
-        const items: DashboardTodoItem[] = [];
+        const items: Omit<DashboardTodoItem, 'userId'>[] = [];
         for (const entity of todoEntities.slice(0, 3)) {
           try {
             const result = await callHaService('todo', 'get_items', {
@@ -63,19 +62,23 @@ export function useDashboardTasks(connected: boolean) {
     return () => clearInterval(interval);
   }, [connected]);
 
-  // Combine local To-Do items + HA task items
-  const localItems: DashboardTodoItem[] = localTasks
-    .getTasksForList('beacon-todo')
-    .map(t => ({
-      uid: t.id,
-      summary: t.summary,
-      status: t.status,
-      listId: 'beacon-todo',
+  const items: DashboardTodoItem[] = useMemo(() => {
+    const local: DashboardTodoItem[] = localTasks
+      .getTasksForList('beacon-todo')
+      .map(t => ({
+        uid: t.id,
+        summary: t.summary,
+        status: t.status,
+        listId: 'beacon-todo',
+      }));
+    const fromHa: DashboardTodoItem[] = haItems.map(i => ({
+      ...i,
+      userId: listByUser[i.listId]?.childId,
     }));
+    return [...local, ...fromHa];
+  }, [localTasks, haItems, listByUser]);
 
-  const allItems = [...localItems, ...haItems];
-
-  const toggleItem = useCallback(async (uid: string, currentStatus: string) => {
+  const toggleItem = useCallback(async (uid: string, currentStatus: string, listId?: string) => {
     // Check if it's a local item
     const localItem = localTasks.getTasksForList('beacon-todo').find(t => t.id === uid);
     if (localItem) {
@@ -83,8 +86,8 @@ export function useDashboardTasks(connected: boolean) {
       return;
     }
 
-    // HA item — find the list and toggle
-    const haItem = haItems.find(i => i.uid === uid);
+    const haItem = haItems.find(i => i.uid === uid && (listId == null || i.listId === listId))
+      ?? haItems.find(i => i.uid === uid);
     if (!haItem) return;
     const newStatus = currentStatus === 'needs_action' ? 'completed' : 'needs_action';
     try {
@@ -94,14 +97,16 @@ export function useDashboardTasks(connected: boolean) {
         status: newStatus,
       });
       setHaItems(prev => prev.map(i =>
-        i.uid === uid ? { ...i, status: newStatus as 'needs_action' | 'completed' } : i
+        i.uid === uid && i.listId === haItem.listId
+          ? { ...i, status: newStatus as 'needs_action' | 'completed' }
+          : i
       ));
     } catch (err) {
       console.warn('Failed to toggle todo item:', err);
     }
   }, [localTasks, haItems]);
 
-  return { items: allItems, toggleItem };
+  return { items, toggleItem, users };
 }
 
 const GROCERY_KEYWORDS = [

--- a/src/hooks/useLocalTasks.ts
+++ b/src/hooks/useLocalTasks.ts
@@ -12,6 +12,7 @@ export interface LocalTask {
   status: 'needs_action' | 'completed';
   listId: string;
   createdAt: string;
+  completedAt?: string;
 }
 
 export interface LocalTaskList {
@@ -66,7 +67,9 @@ export function useLocalTasks() {
   const toggleTask = useCallback((taskId: string) => {
     setTasks(prev => prev.map(t =>
       t.id === taskId
-        ? { ...t, status: t.status === 'needs_action' ? 'completed' : 'needs_action' }
+        ? t.status === 'needs_action'
+          ? { ...t, status: 'completed', completedAt: new Date().toISOString() }
+          : { ...t, status: 'needs_action', completedAt: undefined }
         : t
     ));
   }, []);

--- a/src/hooks/useTaskmate.ts
+++ b/src/hooks/useTaskmate.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect } from 'react';
+import { haFetch, hasToken } from '../api/ha-rest';
+import { TaskmateUser } from '../types/taskmate';
+
+interface HaState {
+  entity_id: string;
+  state: string;
+  attributes: Record<string, unknown>;
+}
+
+interface OverviewChild {
+  id: string;
+  name: string;
+}
+
+export interface UseTaskmateResult {
+  users: TaskmateUser[];
+  listByUser: Record<string, TaskmateUser>;
+}
+
+function findOverview(states: HaState[]): HaState | undefined {
+  return states.find(
+    (s) =>
+      s.entity_id.startsWith('sensor.') &&
+      s.entity_id.endsWith('_overview') &&
+      Array.isArray(s.attributes.children),
+  );
+}
+
+export function useTaskmate(connected: boolean): UseTaskmateResult {
+  const [users, setUsers] = useState<TaskmateUser[]>([]);
+
+  useEffect(() => {
+    if (!connected && !hasToken()) return;
+
+    async function fetchTaskmate() {
+      try {
+        const states = (await haFetch('/api/states')) as HaState[];
+        const byEntity = new Map(states.map((s) => [s.entity_id, s]));
+
+        const overview = findOverview(states);
+        if (!overview) {
+          setUsers([]);
+          return;
+        }
+
+        const byChildId = new Map(
+          ((overview.attributes.children as OverviewChild[]) ?? []).map((c) => [c.id, c]),
+        );
+
+        const resolved: TaskmateUser[] = [];
+        const seen = new Set<string>();
+
+        for (const s of states) {
+          if (!s.entity_id.startsWith('todo.') || s.state === 'unavailable') continue;
+          const stats = byEntity.get(`sensor.${s.entity_id.slice('todo.'.length)}_stats`);
+          const childId = stats ? (stats.attributes.child_id as string | undefined) : undefined;
+          const child = childId ? byChildId.get(childId) : undefined;
+          if (!child || seen.has(child.id)) continue;
+          seen.add(child.id);
+
+          resolved.push({ childId: child.id, name: child.name, todoListId: s.entity_id });
+        }
+
+        resolved.sort((a, b) => a.name.localeCompare(b.name));
+        setUsers(resolved);
+      } catch (err) {
+        console.warn('Failed to fetch TaskMate users:', err);
+      }
+    }
+
+    fetchTaskmate();
+    const interval = setInterval(fetchTaskmate, 60_000);
+    return () => clearInterval(interval);
+  }, [connected]);
+
+  const listByUser: Record<string, TaskmateUser> = {};
+  for (const u of users) listByUser[u.todoListId] = u;
+
+  return { users, listByUser };
+}

--- a/src/hooks/useTaskmate.ts
+++ b/src/hooks/useTaskmate.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { haFetch, hasToken } from '../api/ha-rest';
-import { TaskmateUser } from '../types/taskmate';
+import { TaskmateUser, TaskmateCompletion } from '../types/taskmate';
 
 interface HaState {
   entity_id: string;
@@ -13,9 +13,17 @@ interface OverviewChild {
   name: string;
 }
 
+interface CompletionRaw {
+  chore_id?: string;
+  child_id?: string;
+  chore_name?: string;
+  completed_at?: string;
+}
+
 export interface UseTaskmateResult {
   users: TaskmateUser[];
   listByUser: Record<string, TaskmateUser>;
+  completions: TaskmateCompletion[];
 }
 
 function findOverview(states: HaState[]): HaState | undefined {
@@ -29,6 +37,7 @@ function findOverview(states: HaState[]): HaState | undefined {
 
 export function useTaskmate(connected: boolean): UseTaskmateResult {
   const [users, setUsers] = useState<TaskmateUser[]>([]);
+  const [completions, setCompletions] = useState<TaskmateCompletion[]>([]);
 
   useEffect(() => {
     if (!connected && !hasToken()) return;
@@ -41,6 +50,7 @@ export function useTaskmate(connected: boolean): UseTaskmateResult {
         const overview = findOverview(states);
         if (!overview) {
           setUsers([]);
+          setCompletions([]);
           return;
         }
 
@@ -64,6 +74,24 @@ export function useTaskmate(connected: boolean): UseTaskmateResult {
 
         resolved.sort((a, b) => a.name.localeCompare(b.name));
         setUsers(resolved);
+
+        const choresSensor = states.find((s) => Array.isArray(s.attributes.todays_completions));
+        const raw = (choresSensor?.attributes.todays_completions as CompletionRaw[] | undefined) ?? [];
+        const seenComp = new Set<string>();
+        const done: TaskmateCompletion[] = [];
+        for (const c of raw) {
+          if (!c.chore_id || !c.child_id) continue;
+          const key = `${c.child_id}:${c.chore_id}`;
+          if (seenComp.has(key)) continue;
+          seenComp.add(key);
+          done.push({
+            uid: c.chore_id,
+            summary: c.chore_name ?? '',
+            userId: c.child_id,
+            completedAt: c.completed_at ?? '',
+          });
+        }
+        setCompletions(done);
       } catch (err) {
         console.warn('Failed to fetch TaskMate users:', err);
       }
@@ -77,5 +105,5 @@ export function useTaskmate(connected: boolean): UseTaskmateResult {
   const listByUser: Record<string, TaskmateUser> = {};
   for (const u of users) listByUser[u.todoListId] = u;
 
-  return { users, listByUser };
+  return { users, listByUser, completions };
 }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -567,6 +567,41 @@
   font-weight: 500;
 }
 
+.task-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.task-group { display: flex; flex-direction: column; gap: 4px; }
+
+.task-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 4px 2px;
+}
+
+.task-group-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1.5px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.task-group-name { font-size: 0.8rem; font-weight: 700; }
+
+.task-groups .task-checklist { flex: none; overflow-y: visible; }
+
 /* ─── Responsive: Tablet < 768px ─── */
 @media (max-width: 768px) {
   .dashboard {

--- a/src/types/taskmate.ts
+++ b/src/types/taskmate.ts
@@ -1,0 +1,5 @@
+export interface TaskmateUser {
+  childId: string;
+  name: string;
+  todoListId: string;
+}

--- a/src/types/taskmate.ts
+++ b/src/types/taskmate.ts
@@ -3,3 +3,10 @@ export interface TaskmateUser {
   name: string;
   todoListId: string;
 }
+
+export interface TaskmateCompletion {
+  uid: string;
+  summary: string;
+  userId: string;
+  completedAt: string;
+}


### PR DESCRIPTION
In TaskMate, when a single task is created and assigned to multiple people, the UI breaks. It will render the tasks twice, and then when one is checked, it marks both as done in the UI until the page is refreshed.

This fixes it by taking the user into account. Now, the UI will only mark it as done for the specific user rather than for all of the users.

<img width="336" height="312" alt="image" src="https://github.com/user-attachments/assets/e96bf6b9-626c-45f6-bc93-64b5bb9c81f7" />

If the task is finished within the day, it will still show but crossed out to indicate that it's been done. This is based on the completion date marked in TaskMate.

<img width="318" height="291" alt="image" src="https://github.com/user-attachments/assets/89af6656-1403-4632-8cf9-8bd68c25b0fc" />
