### PR TITLE
Use HA_API_BASE instead of supervisor

### DIFF
--- a/beacon/server.js
+++ b/beacon/server.js
@@ -456,10 +456,11 @@ function parseIntent(text) {
 function haRequest(method, apiPath, body) {
   return new Promise((resolve, reject) => {
     const bodyBuf = body ? Buffer.from(JSON.stringify(body), 'utf8') : null;
+    const url = new URL(`${HA_API_BASE}${apiPath}`);
     const options = {
-      hostname: 'supervisor',
-      port: 80,
-      path: `/core${apiPath}`,
+      hostname: url.hostname,
+      port: url.port || 80,
+      path: url.pathname + url.search,
       method,
       headers: {
         'Authorization': `Bearer ${SUPERVISOR_TOKEN}`,

--- a/server.js
+++ b/server.js
@@ -456,10 +456,11 @@ function parseIntent(text) {
 function haRequest(method, apiPath, body) {
   return new Promise((resolve, reject) => {
     const bodyBuf = body ? Buffer.from(JSON.stringify(body), 'utf8') : null;
+    const url = new URL(`${HA_API_BASE}${apiPath}`);
     const options = {
-      hostname: 'supervisor',
-      port: 80,
-      path: `/core${apiPath}`,
+      hostname: url.hostname,
+      port: url.port || 80,
+      path: url.pathname + url.search,
       method,
       headers: {
         'Authorization': `Bearer ${SUPERVISOR_TOKEN}`,


### PR DESCRIPTION
When this is executed in a docker environment outside of HA, it fails because it tries to hit supervisor, which doesn't exist.

This uses the HA_API_BASE, which should take the override into account. When override is not configured, it defaults to `supervisor` since if the HA_API_BASE is not passed in.