### PR TITLE
feat(dashboard): add day navigation to day view

### DIFF
--- a/beacon/src/App.tsx
+++ b/beacon/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { startOfWeek, addDays, format } from 'date-fns';
+import { startOfWeek, startOfDay, addDays, format } from 'date-fns';
 import { useHomeAssistant } from './hooks/useHomeAssistant';
 import { useCalendarEvents, CalendarNotSupportedError } from './hooks/useCalendarEvents';
 import { useFamily } from './hooks/useFamily';
@@ -179,6 +179,9 @@ export function App() {
   const [visibleWeekStart, setVisibleWeekStart] = useState<Date>(() =>
     startOfWeek(new Date(), { weekStartsOn: 0 }),
   );
+
+  // Day currently selected on the Dashboard's day view
+  const [dashboardDate, setDashboardDate] = useState<Date>(() => startOfDay(new Date()));
 
   // Helper: refetch events for a given week, with one extra day on either side
   // so multi-day events that bleed in/out of the visible week still render.
@@ -387,10 +390,11 @@ export function App() {
 
   const handleAddEvent = useCallback(() => {
     setSelectedEvent(null);
-    setPrefillDate(null);
+    // Default new events to the day currently selected on the dashboard.
+    setPrefillDate(activeView === 'dashboard' ? format(dashboardDate, 'yyyy-MM-dd') : null);
     setPrefillTime(null);
     setShowModal(true);
-  }, []);
+  }, [activeView, dashboardDate]);
 
   const handleChangeView = useCallback(
     (view: SidebarView) => {
@@ -560,6 +564,8 @@ export function App() {
               onEventClick={handleEventClick}
               members={members}
               layout={settings.dashboardLayout}
+              selectedDate={dashboardDate}
+              onSelectedDateChange={setDashboardDate}
             />
             <OmniAdd
               onAddEvent={handleAddEvent}

--- a/beacon/src/components/DashboardView.tsx
+++ b/beacon/src/components/DashboardView.tsx
@@ -34,6 +34,8 @@ interface DashboardViewProps {
   onEventClick?: (event: CalendarEvent) => void;
   members?: FamilyMember[];
   layout?: 'default' | 'classic' | 'compact';
+  selectedDate: Date;
+  onSelectedDateChange: (date: Date) => void;
 }
 
 export function DashboardView({
@@ -48,6 +50,8 @@ export function DashboardView({
   onEventClick,
   members = [],
   layout = 'default',
+  selectedDate,
+  onSelectedDateChange,
 }: DashboardViewProps) {
   const [now, setNow] = useState(new Date());
   const [selectedMemberFilter, setSelectedMemberFilter] = useState<string | null>(null);
@@ -55,6 +59,11 @@ export function DashboardView({
   const toggleMemberFilter = (memberId: string) => {
     setSelectedMemberFilter((prev) => (prev === memberId ? null : memberId));
   };
+
+  const goToPreviousDay = () => onSelectedDateChange(addDays(selectedDate, -1));
+  const goToNextDay = () => onSelectedDateChange(addDays(selectedDate, 1));
+  const goToToday = () => onSelectedDateChange(startOfDay(new Date()));
+  const isViewingToday = isSameDay(selectedDate, startOfDay(now));
 
   const filteredChores = selectedMemberFilter
     ? chores.filter((c) => c.assigned_to.includes(selectedMemberFilter))
@@ -68,16 +77,15 @@ export function DashboardView({
   const timeString = format(now, 'h:mm');
   const dateString = format(now, 'EEEE, MMMM d');
 
-  const { byMember, other } = useFamilyEvents(events, members);
+  const { byMember, other } = useFamilyEvents(events, members, selectedDate);
   const { todaysMenu } = useMealPlans();
 
-  // Also compute flat today's events for the "other" / fallback view
+  // Events for the currently selected day, used by the "other" / fallback view
   const todayEvents = useMemo(() => {
-    const today = startOfDay(new Date());
     return events
-      .filter((e) => isSameDay(startOfDay(parseISO(e.start)), today))
+      .filter((e) => isSameDay(startOfDay(parseISO(e.start)), selectedDate))
       .sort((a, b) => a.start.localeCompare(b.start));
-  }, [events]);
+  }, [events, selectedDate]);
 
   const hasMemberCalendars = members.some(
     (m) => m.calendar_entity || (m.additional_calendar_entities?.length ?? 0) > 0,
@@ -100,7 +108,32 @@ export function DashboardView({
     <header className="dash-topbar">
       <div className="dash-topbar-left">
         <span className="dash-topbar-time">{timeString}</span>
-        <span className="dash-topbar-date">{dateString}</span>
+        <div className="dash-topbar-date-nav">
+          <button
+            type="button"
+            className="dash-day-nav-btn"
+            onClick={goToPreviousDay}
+            aria-label="Previous day"
+          >
+            ‹
+          </button>
+          <span className="dash-topbar-date">
+            {isViewingToday ? dateString : format(selectedDate, 'EEEE, MMMM d')}
+          </span>
+          <button
+            type="button"
+            className="dash-day-nav-btn"
+            onClick={goToNextDay}
+            aria-label="Next day"
+          >
+            ›
+          </button>
+          {!isViewingToday && (
+            <button type="button" className="dash-day-nav-today" onClick={goToToday}>
+              Today
+            </button>
+          )}
+        </div>
       </div>
       {weather && (
         <div
@@ -181,10 +214,9 @@ export function DashboardView({
         {topbar}
         <main className="dash-classic">
           <section className="dash-classic-col">
-            <h2 className="dashboard-section-title">Today</h2>
             <div className="dashboard-events-scroll">
               {todayEvents.length === 0 ? (
-                <div className="dashboard-empty">Nothing scheduled today</div>
+                <div className="dashboard-empty">Nothing scheduled {isViewingToday ? 'today' : 'this day'}</div>
               ) : (
                 <div className="dashboard-events-list">
                   {todayEvents.map((event) => (
@@ -231,9 +263,10 @@ export function DashboardView({
       {/* ─── MAIN: Per-member calendar columns ─── */}
       <main className="dash-main">
         {hasMemberCalendars ? (
-          <div className="dash-family-grid" style={{ '--member-count': members.length } as React.CSSProperties}>
-            {members.map((member) => {
-              const memberEvents = byMember.get(member.id) || [];
+          <>
+            <div className="dash-family-grid" style={{ '--member-count': members.length } as React.CSSProperties}>
+              {members.map((member) => {
+                const memberEvents = byMember.get(member.id) || [];
               const isSelected = selectedMemberFilter === member.id;
               return (
                 <section key={member.id} className={`dash-member-col ${isSelected ? 'dash-member-col--selected' : ''}`}>
@@ -256,7 +289,7 @@ export function DashboardView({
                   </button>
                   <div className="dash-member-events">
                     {memberEvents.length === 0 ? (
-                      <div className="dash-member-empty">Nothing today</div>
+                      <div className="dash-member-empty">Nothing scheduled {isViewingToday ? 'today' : 'this day'}</div>
                     ) : (
                       memberEvents.map((event) => (
                         <EventCard key={event.id} event={event} onClick={onEventClick} />
@@ -281,11 +314,11 @@ export function DashboardView({
                 </div>
               </section>
             )}
-          </div>
+            </div>
+          </>
         ) : (
           /* Fallback: flat event list when no members have calendars assigned */
           <div className="dash-events-fallback">
-            <h2 className="dashboard-section-title">Today</h2>
             <div className="dashboard-events-scroll">
               {todayEvents.length === 0 ? (
                 <div className="dashboard-empty">Nothing scheduled — your day is wide open</div>

--- a/beacon/src/hooks/useFamilyEvents.ts
+++ b/beacon/src/hooks/useFamilyEvents.ts
@@ -11,17 +11,18 @@ export interface FamilyEventsMap {
 }
 
 /**
- * Groups today's calendar events by family member using their
+ * Groups a given day's calendar events by family member using their
  * calendar_entity field. Unmatched events go into `other`.
  */
 export function useFamilyEvents(
   events: CalendarEvent[],
   members: FamilyMember[],
+  referenceDate: Date = new Date(),
 ): FamilyEventsMap {
   return useMemo(() => {
-    const today = startOfDay(new Date());
+    const day = startOfDay(referenceDate);
     const todayEvents = events.filter((e) =>
-      isSameDay(startOfDay(parseISO(e.start)), today),
+      isSameDay(startOfDay(parseISO(e.start)), day),
     );
 
     // Build a calendarId → memberId lookup (primary + additional calendars)
@@ -58,5 +59,5 @@ export function useFamilyEvents(
     other.sort((a, b) => a.start.localeCompare(b.start));
 
     return { byMember, other };
-  }, [events, members]);
+  }, [events, members, referenceDate]);
 }

--- a/beacon/src/styles/dashboard.css
+++ b/beacon/src/styles/dashboard.css
@@ -132,6 +132,12 @@
   color: var(--text-secondary);
 }
 
+.dash-topbar-date-nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .dash-topbar-weather {
   display: flex;
   align-items: center;
@@ -351,6 +357,43 @@
   letter-spacing: 1px;
   margin-bottom: 16px;
   flex-shrink: 0;
+}
+
+.dash-day-nav-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--border, #e5e5e5);
+  background: var(--bg-elevated, transparent);
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.dash-day-nav-btn:hover {
+  background: var(--bg-hover);
+}
+
+.dash-day-nav-today {
+  border: none;
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 4px 10px;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.dash-day-nav-today:hover {
+  background: var(--border, #e5e5e5);
 }
 
 .dashboard-events-scroll {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { startOfWeek, addDays, format } from 'date-fns';
+import { startOfWeek, startOfDay, addDays, format } from 'date-fns';
 import { useHomeAssistant } from './hooks/useHomeAssistant';
 import { useCalendarEvents, CalendarNotSupportedError } from './hooks/useCalendarEvents';
 import { useFamily } from './hooks/useFamily';
@@ -179,6 +179,9 @@ export function App() {
   const [visibleWeekStart, setVisibleWeekStart] = useState<Date>(() =>
     startOfWeek(new Date(), { weekStartsOn: 0 }),
   );
+
+  // Day currently selected on the Dashboard's day view
+  const [dashboardDate, setDashboardDate] = useState<Date>(() => startOfDay(new Date()));
 
   // Helper: refetch events for a given week, with one extra day on either side
   // so multi-day events that bleed in/out of the visible week still render.
@@ -387,10 +390,11 @@ export function App() {
 
   const handleAddEvent = useCallback(() => {
     setSelectedEvent(null);
-    setPrefillDate(null);
+    // Default new events to the day currently selected on the dashboard.
+    setPrefillDate(activeView === 'dashboard' ? format(dashboardDate, 'yyyy-MM-dd') : null);
     setPrefillTime(null);
     setShowModal(true);
-  }, []);
+  }, [activeView, dashboardDate]);
 
   const handleChangeView = useCallback(
     (view: SidebarView) => {
@@ -560,6 +564,8 @@ export function App() {
               onEventClick={handleEventClick}
               members={members}
               layout={settings.dashboardLayout}
+              selectedDate={dashboardDate}
+              onSelectedDateChange={setDashboardDate}
             />
             <OmniAdd
               onAddEvent={handleAddEvent}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -34,6 +34,8 @@ interface DashboardViewProps {
   onEventClick?: (event: CalendarEvent) => void;
   members?: FamilyMember[];
   layout?: 'default' | 'classic' | 'compact';
+  selectedDate: Date;
+  onSelectedDateChange: (date: Date) => void;
 }
 
 export function DashboardView({
@@ -48,6 +50,8 @@ export function DashboardView({
   onEventClick,
   members = [],
   layout = 'default',
+  selectedDate,
+  onSelectedDateChange,
 }: DashboardViewProps) {
   const [now, setNow] = useState(new Date());
   const [selectedMemberFilter, setSelectedMemberFilter] = useState<string | null>(null);
@@ -55,6 +59,11 @@ export function DashboardView({
   const toggleMemberFilter = (memberId: string) => {
     setSelectedMemberFilter((prev) => (prev === memberId ? null : memberId));
   };
+
+  const goToPreviousDay = () => onSelectedDateChange(addDays(selectedDate, -1));
+  const goToNextDay = () => onSelectedDateChange(addDays(selectedDate, 1));
+  const goToToday = () => onSelectedDateChange(startOfDay(new Date()));
+  const isViewingToday = isSameDay(selectedDate, startOfDay(now));
 
   const filteredChores = selectedMemberFilter
     ? chores.filter((c) => c.assigned_to.includes(selectedMemberFilter))
@@ -68,16 +77,15 @@ export function DashboardView({
   const timeString = format(now, 'h:mm');
   const dateString = format(now, 'EEEE, MMMM d');
 
-  const { byMember, other } = useFamilyEvents(events, members);
+  const { byMember, other } = useFamilyEvents(events, members, selectedDate);
   const { todaysMenu } = useMealPlans();
 
-  // Also compute flat today's events for the "other" / fallback view
+  // Events for the currently selected day, used by the "other" / fallback view
   const todayEvents = useMemo(() => {
-    const today = startOfDay(new Date());
     return events
-      .filter((e) => isSameDay(startOfDay(parseISO(e.start)), today))
+      .filter((e) => isSameDay(startOfDay(parseISO(e.start)), selectedDate))
       .sort((a, b) => a.start.localeCompare(b.start));
-  }, [events]);
+  }, [events, selectedDate]);
 
   const hasMemberCalendars = members.some(
     (m) => m.calendar_entity || (m.additional_calendar_entities?.length ?? 0) > 0,
@@ -100,7 +108,32 @@ export function DashboardView({
     <header className="dash-topbar">
       <div className="dash-topbar-left">
         <span className="dash-topbar-time">{timeString}</span>
-        <span className="dash-topbar-date">{dateString}</span>
+        <div className="dash-topbar-date-nav">
+          <button
+            type="button"
+            className="dash-day-nav-btn"
+            onClick={goToPreviousDay}
+            aria-label="Previous day"
+          >
+            ‹
+          </button>
+          <span className="dash-topbar-date">
+            {isViewingToday ? dateString : format(selectedDate, 'EEEE, MMMM d')}
+          </span>
+          <button
+            type="button"
+            className="dash-day-nav-btn"
+            onClick={goToNextDay}
+            aria-label="Next day"
+          >
+            ›
+          </button>
+          {!isViewingToday && (
+            <button type="button" className="dash-day-nav-today" onClick={goToToday}>
+              Today
+            </button>
+          )}
+        </div>
       </div>
       {weather && (
         <div
@@ -181,10 +214,9 @@ export function DashboardView({
         {topbar}
         <main className="dash-classic">
           <section className="dash-classic-col">
-            <h2 className="dashboard-section-title">Today</h2>
             <div className="dashboard-events-scroll">
               {todayEvents.length === 0 ? (
-                <div className="dashboard-empty">Nothing scheduled today</div>
+                <div className="dashboard-empty">Nothing scheduled {isViewingToday ? 'today' : 'this day'}</div>
               ) : (
                 <div className="dashboard-events-list">
                   {todayEvents.map((event) => (
@@ -231,9 +263,10 @@ export function DashboardView({
       {/* ─── MAIN: Per-member calendar columns ─── */}
       <main className="dash-main">
         {hasMemberCalendars ? (
-          <div className="dash-family-grid" style={{ '--member-count': members.length } as React.CSSProperties}>
-            {members.map((member) => {
-              const memberEvents = byMember.get(member.id) || [];
+          <>
+            <div className="dash-family-grid" style={{ '--member-count': members.length } as React.CSSProperties}>
+              {members.map((member) => {
+                const memberEvents = byMember.get(member.id) || [];
               const isSelected = selectedMemberFilter === member.id;
               return (
                 <section key={member.id} className={`dash-member-col ${isSelected ? 'dash-member-col--selected' : ''}`}>
@@ -256,7 +289,7 @@ export function DashboardView({
                   </button>
                   <div className="dash-member-events">
                     {memberEvents.length === 0 ? (
-                      <div className="dash-member-empty">Nothing today</div>
+                      <div className="dash-member-empty">Nothing scheduled {isViewingToday ? 'today' : 'this day'}</div>
                     ) : (
                       memberEvents.map((event) => (
                         <EventCard key={event.id} event={event} onClick={onEventClick} />
@@ -281,11 +314,11 @@ export function DashboardView({
                 </div>
               </section>
             )}
-          </div>
+            </div>
+          </>
         ) : (
           /* Fallback: flat event list when no members have calendars assigned */
           <div className="dash-events-fallback">
-            <h2 className="dashboard-section-title">Today</h2>
             <div className="dashboard-events-scroll">
               {todayEvents.length === 0 ? (
                 <div className="dashboard-empty">Nothing scheduled — your day is wide open</div>

--- a/src/hooks/useFamilyEvents.ts
+++ b/src/hooks/useFamilyEvents.ts
@@ -11,17 +11,18 @@ export interface FamilyEventsMap {
 }
 
 /**
- * Groups today's calendar events by family member using their
+ * Groups a given day's calendar events by family member using their
  * calendar_entity field. Unmatched events go into `other`.
  */
 export function useFamilyEvents(
   events: CalendarEvent[],
   members: FamilyMember[],
+  referenceDate: Date = new Date(),
 ): FamilyEventsMap {
   return useMemo(() => {
-    const today = startOfDay(new Date());
+    const day = startOfDay(referenceDate);
     const todayEvents = events.filter((e) =>
-      isSameDay(startOfDay(parseISO(e.start)), today),
+      isSameDay(startOfDay(parseISO(e.start)), day),
     );
 
     // Build a calendarId → memberId lookup (primary + additional calendars)
@@ -58,5 +59,5 @@ export function useFamilyEvents(
     other.sort((a, b) => a.start.localeCompare(b.start));
 
     return { byMember, other };
-  }, [events, members]);
+  }, [events, members, referenceDate]);
 }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -132,6 +132,12 @@
   color: var(--text-secondary);
 }
 
+.dash-topbar-date-nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .dash-topbar-weather {
   display: flex;
   align-items: center;
@@ -351,6 +357,43 @@
   letter-spacing: 1px;
   margin-bottom: 16px;
   flex-shrink: 0;
+}
+
+.dash-day-nav-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--border, #e5e5e5);
+  background: var(--bg-elevated, transparent);
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.dash-day-nav-btn:hover {
+  background: var(--bg-hover);
+}
+
+.dash-day-nav-today {
+  border: none;
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 4px 10px;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.dash-day-nav-today:hover {
+  background: var(--border, #e5e5e5);
 }
 
 .dashboard-events-scroll {


### PR DESCRIPTION
Add prev/next/today controls merged into the topbar date on the Dashboard, allowing users to browse events for other days. The add-event action now defaults to the currently selected day instead of always defaulting to today.