### PR TITLE
A few improvements to calendar color selection

### DIFF
--- a/beacon/src/App.tsx
+++ b/beacon/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { startOfWeek, startOfDay, addDays, format } from 'date-fns';
 import { useHomeAssistant } from './hooks/useHomeAssistant';
 import { useCalendarEvents, CalendarNotSupportedError } from './hooks/useCalendarEvents';
@@ -232,7 +232,22 @@ export function App() {
     }, 5 * 60 * 1000);
 
     return () => clearInterval(interval);
-  }, [connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart, settings.calendarColors, members]);
+  }, [connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart]);
+
+  // Re-fetch when calendar colors or family members change so colors update
+  // immediately, without recreating the 5-minute polling interval above.
+  const colorRefreshRef = useRef({ connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart });
+  colorRefreshRef.current = { connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart };
+  const didColorRefreshMount = useRef(false);
+  useEffect(() => {
+    if (!didColorRefreshMount.current) {
+      didColorRefreshMount.current = true;
+      return;
+    }
+    if (!colorRefreshRef.current.connected) return;
+    colorRefreshRef.current.fetchCalendars();
+    colorRefreshRef.current.refetchEventsForWeek(colorRefreshRef.current.visibleWeekStart);
+  }, [settings.calendarColors, members]);
 
   const handleToggleCalendar = useCallback((calendarId: string) => {
     setHiddenCalendars(prev => {

--- a/beacon/src/App.tsx
+++ b/beacon/src/App.tsx
@@ -34,7 +34,7 @@ import { useDashboardTasks } from './hooks/useDashboardTasks';
 import OnboardingView from './components/OnboardingView';
 import { FocusView } from './components/focus/FocusView';
 import { getFocusMemberId, clearFocusMode, setDeviceFocusMember } from './focus';
-import { CalendarEvent } from './types';
+import { CalendarEvent, resolveCalendarColor } from './types';
 import { getConfig, patchConfig } from './config';
 
 const config = getConfig();
@@ -74,14 +74,23 @@ export function App() {
 
   const localCal = useLocalCalendar();
 
+  // Resolve the local calendar's color the same way everywhere (user override or indigo default).
+  const localCalendarColor = resolveCalendarColor(localCal.calendar.id, 0, {
+    calendarColors: settings.calendarColors,
+    defaultColor: localCal.calendar.color,
+  });
+
   // Merge HA + local calendars and events
   const calendars = useMemo(
-    () => [localCal.calendar, ...haCalendars],
-    [localCal.calendar, haCalendars],
+    () => [{ ...localCal.calendar, color: localCalendarColor }, ...haCalendars],
+    [localCal.calendar, localCalendarColor, haCalendars],
   );
   const events = useMemo(
-    () => [...localCal.events, ...haEvents].sort((a, b) => a.start.localeCompare(b.start)),
-    [localCal.events, haEvents],
+    () => [
+      ...localCal.events.map((ev) => ({ ...ev, color: localCalendarColor })),
+      ...haEvents,
+    ].sort((a, b) => a.start.localeCompare(b.start)),
+    [localCal.events, localCalendarColor, haEvents],
   );
 
   // Route create/update/delete to local or HA based on calendar ID
@@ -223,7 +232,7 @@ export function App() {
     }, 5 * 60 * 1000);
 
     return () => clearInterval(interval);
-  }, [connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart]);
+  }, [connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart, settings.calendarColors, members]);
 
   const handleToggleCalendar = useCallback((calendarId: string) => {
     setHiddenCalendars(prev => {

--- a/beacon/src/api/homeassistant.ts
+++ b/beacon/src/api/homeassistant.ts
@@ -206,6 +206,7 @@ export class HomeAssistantClient {
       start: string | { dateTime: string; date: string };
       end: string | { dateTime: string; date: string };
       description?: string;
+      location?: string;
       recurrence_id?: string;
     }>;
 
@@ -223,6 +224,7 @@ export class HomeAssistantClient {
         end: endStr,
         allDay,
         description: ev.description,
+        location: ev.location,
         calendarId,
         calendarName: calendarId,
         color: '', // will be set by consumer

--- a/beacon/src/components/EventBlock.tsx
+++ b/beacon/src/components/EventBlock.tsx
@@ -46,7 +46,7 @@ export function EventBlock({ event, onClick, style, allDay, multiDay, draggable,
       }}
       onClick={(e) => onClick(event, e)}
       type="button"
-      title={`${event.title} (${timeLabel})`}
+      title={`${event.title}${event.location ? ` — ${event.location}` : ''} (${timeLabel})`}
       draggable={draggable}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
@@ -55,6 +55,9 @@ export function EventBlock({ event, onClick, style, allDay, multiDay, draggable,
       <div className="event-block-stripe" style={{ backgroundColor: full }} />
       <div className="event-block-content">
         <span className="event-block-title">{event.title}</span>
+        {event.location && (
+          <span className="event-block-location">{event.location}</span>
+        )}
         {!allDay && (
           <span className="event-block-time">{timeLabel}</span>
         )}

--- a/beacon/src/components/EventCard.tsx
+++ b/beacon/src/components/EventCard.tsx
@@ -28,6 +28,7 @@ export function EventCard({ event, onClick }: EventCardProps) {
     >
       <span className="event-card-calendar">{event.calendarName}</span>
       <span className="event-card-title">{event.title}</span>
+      {event.location && <span className="event-card-location">{event.location}</span>}
       <span className="event-card-time">{timeLabel}</span>
     </div>
   );

--- a/beacon/src/components/SettingsView.tsx
+++ b/beacon/src/components/SettingsView.tsx
@@ -17,10 +17,16 @@ import {
 import { AnyListClient } from '../api/anylist';
 import { GroceryList } from '../types/grocery';
 import { themes } from '../styles/themes';
-import { FamilyMember, MEMBER_COLORS, AVATAR_CATEGORIES, Routine } from '../types/family';
+import {
+  FamilyMember,
+  MEMBER_COLORS,
+  AVATAR_CATEGORIES,
+  Routine,
+} from '../types/family';
 import type { BeaconSettings } from '../hooks/useSettings';
 import { buildFocusUrl } from '../focus';
 import { useRoutines } from '../hooks/useRoutines';
+import { resolveCalendarColor, CALENDAR_COLOR_PRESETS } from '../types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -52,7 +58,7 @@ interface SettingsViewProps {
   connected: boolean;
   haUrl: string;
   // Calendars
-  calendars: Array<{ id: string; name: string }>;
+  calendars: Array<{ id: string; name: string; color?: string }>;
   // Kid Display
   onEnterFocusMode: (memberId: string) => void;
 }
@@ -206,6 +212,7 @@ export function SettingsView({
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [kidDisplayMemberId, setKidDisplayMemberId] = useState('');
   const [copiedFocusUrl, setCopiedFocusUrl] = useState(false);
+  const [colorEditId, setColorEditId] = useState<string | null>(null);
 
   // ---- Routine editor state ----
   const routinesApi = useRoutines();
@@ -1128,45 +1135,99 @@ export function SettingsView({
             </div>
           </div>
         ) : (
-          calendars.map((cal) => {
+          calendars.map((cal, index) => {
             const isHidden = settings.permanentlyHiddenCalendars.includes(cal.id);
-            const color = settings.calendarColors[cal.id] || '';
+            const customColor = settings.calendarColors[cal.id] || '';
+            const resolvedColor = resolveCalendarColor(cal.id, index, {
+              calendarColors: settings.calendarColors,
+              members,
+              defaultColor: cal.color,
+            });
+            const open = colorEditId === cal.id;
+
+            const setColor = (value: string) => {
+              onUpdateSettings({
+                calendarColors: { ...settings.calendarColors, [cal.id]: value },
+              });
+            };
+            const resetColor = () => {
+              const next = { ...settings.calendarColors };
+              delete next[cal.id];
+              onUpdateSettings({ calendarColors: next });
+            };
+
             return (
-              <div key={cal.id} className="settings-row">
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
-                  <input
-                    type="color"
-                    value={color || '#3b82f6'}
-                    onChange={(e) => {
-                      onUpdateSettings({
-                        calendarColors: { ...settings.calendarColors, [cal.id]: e.target.value },
-                      });
-                    }}
+              <div key={cal.id} className="settings-calendar-row">
+                <div className="settings-row">
+                  <div
                     style={{
-                      width: 24,
-                      height: 24,
-                      borderRadius: '50%',
-                      border: '1px solid var(--border)',
-                      cursor: 'pointer',
-                      padding: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      flex: 1,
+                      minWidth: 0,
                     }}
-                    title="Calendar color"
-                  />
-                  <div>
-                    <div className="settings-row-label">{cal.name}</div>
-                    <div className="settings-row-sublabel">{cal.id}</div>
+                  >
+                    <button
+                      type="button"
+                      className="settings-calendar-color-swatch"
+                      style={{ backgroundColor: resolvedColor }}
+                      onClick={() => setColorEditId(open ? null : cal.id)}
+                      title="Edit calendar color"
+                      aria-label={`Edit color for ${cal.name}`}
+                      aria-expanded={open}
+                    />
+                    <div style={{ minWidth: 0 }}>
+                      <div className="settings-row-label">{cal.name}</div>
+                      <div className="settings-row-sublabel">{cal.id}</div>
+                    </div>
                   </div>
+                  <Toggle
+                    checked={!isHidden}
+                    onChange={(visible) => {
+                      const hidden = settings.permanentlyHiddenCalendars.filter(
+                        (id) => id !== cal.id,
+                      );
+                      if (!visible) hidden.push(cal.id);
+                      onUpdateSettings({ permanentlyHiddenCalendars: hidden });
+                    }}
+                  />
                 </div>
-                <Toggle
-                  checked={!isHidden}
-                  onChange={(visible) => {
-                    const hidden = settings.permanentlyHiddenCalendars.filter(
-                      (id) => id !== cal.id,
-                    );
-                    if (!visible) hidden.push(cal.id);
-                    onUpdateSettings({ permanentlyHiddenCalendars: hidden });
-                  }}
-                />
+                {open && (
+                  <div className="settings-color-editor">
+                    <div className="settings-color-grid">
+                      {CALENDAR_COLOR_PRESETS.map((preset) => (
+                        <button
+                          key={preset}
+                          type="button"
+                          className={`settings-color-circle ${customColor === preset ? 'settings-color-circle--selected' : ''}`}
+                          style={{ backgroundColor: preset }}
+                          onClick={() => setColor(preset)}
+                          aria-label={`Set ${cal.name} to ${preset}`}
+                        />
+                      ))}
+                    </div>
+                    <div className="settings-color-editor-custom">
+                      <label className="settings-color-custom">
+                        <input
+                          type="color"
+                          value={customColor || resolvedColor}
+                          onChange={(e) => setColor(e.target.value)}
+                          aria-label={`Choose a custom color for ${cal.name}`}
+                        />
+                        <span>Custom…</span>
+                      </label>
+                      <button
+                        type="button"
+                        className="settings-btn"
+                        onClick={resetColor}
+                        disabled={!customColor}
+                      >
+                        Reset to auto
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             );
           })

--- a/beacon/src/hooks/useCalendarEvents.ts
+++ b/beacon/src/hooks/useCalendarEvents.ts
@@ -88,6 +88,7 @@ export function useCalendarEvents(
             start: string | { dateTime: string; date: string };
             end: string | { dateTime: string; date: string };
             description?: string;
+            location?: string;
             recurrence_id?: string;
           }>;
 
@@ -112,6 +113,7 @@ export function useCalendarEvents(
               end: endStr,
               allDay,
               description: ev.description,
+              location: ev.location,
               calendarId: cal.id,
               calendarName: cal.name,
               color: cal.color,

--- a/beacon/src/styles/beacon.css
+++ b/beacon/src/styles/beacon.css
@@ -1073,6 +1073,16 @@ a:focus:not(:focus-visible) {
   line-height: 1.2;
 }
 
+.event-block-location {
+  font-size: 0.65rem;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.55);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
 /* All-day event blocks */
 .event-block--allday {
   position: relative;
@@ -1883,6 +1893,10 @@ a:focus:not(:focus-visible) {
   }
 
   .event-block-time {
+    display: none;
+  }
+
+  .event-block-location {
     display: none;
   }
 

--- a/beacon/src/styles/dashboard.css
+++ b/beacon/src/styles/dashboard.css
@@ -478,10 +478,19 @@
   color: rgba(0, 0, 0, 0.5);
 }
 
+.event-card-location {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.5);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 [data-theme="dark"] .event-card { box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3); }
 [data-theme="dark"] .event-card-calendar { color: rgba(0, 0, 0, 0.5); }
 [data-theme="dark"] .event-card-title { color: rgba(0, 0, 0, 0.85); }
 [data-theme="dark"] .event-card-time { color: rgba(0, 0, 0, 0.5); }
+[data-theme="dark"] .event-card-location { color: rgba(0, 0, 0, 0.5); }
 
 /* --- Task Checklist --- */
 .task-checklist {

--- a/beacon/src/styles/settings.css
+++ b/beacon/src/styles/settings.css
@@ -427,6 +427,74 @@
   box-shadow: 0 0 0 2px var(--bg-surface), 0 0 0 4px var(--text-primary);
 }
 
+/* --- Per-calendar color editor --- */
+.settings-calendar-row {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-calendar-row:last-child {
+  border-bottom: none;
+}
+
+.settings-calendar-color-swatch {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid var(--bg-surface);
+  box-shadow: 0 0 0 1px var(--border);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--transition);
+}
+
+.settings-calendar-color-swatch:hover {
+  transform: scale(1.12);
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+.settings-color-editor {
+  border-top: 1px dashed var(--border-subtle);
+  background: color-mix(in srgb, var(--bg-surface) 55%, transparent);
+  padding: 12px 0 16px;
+}
+
+.settings-color-editor .settings-color-grid {
+  padding: 0 20px 12px;
+}
+
+.settings-color-editor-custom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 20px;
+  flex-wrap: wrap;
+}
+
+.settings-color-custom {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.settings-color-custom input[type="color"] {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  cursor: pointer;
+  background: none;
+}
+
+.settings-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 /* --- Button styles for settings --- */
 .settings-btn {
   padding: 8px 18px;

--- a/beacon/src/types.test.ts
+++ b/beacon/src/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   CALENDAR_COLORS,
+  CALENDAR_COLOR_PRESETS,
   getCalendarColor,
   getPastelColor,
   getFullColor,
@@ -26,26 +27,36 @@ describe('CALENDAR_COLORS', () => {
 });
 
 describe('getCalendarColor', () => {
-  it('returns the color at the given index', () => {
-    expect(getCalendarColor(0)).toBe(CALENDAR_COLORS[0]);
-    expect(getCalendarColor(1)).toBe(CALENDAR_COLORS[1]);
+  it('keeps the original category colors for the first four calendars', () => {
+    expect([0, 1, 2, 3].map(getCalendarColor)).toEqual(Object.values(CALENDAR_COLORS));
   });
 
-  it('wraps around via modulo once index exceeds the category count', () => {
-    // 4 categories, so index 4 should wrap back to index 0's color
-    expect(getCalendarColor(4)).toBe(getCalendarColor(0));
-    expect(getCalendarColor(5)).toBe(getCalendarColor(1));
+  it('walks the full preset palette before wrapping (no early collisions)', () => {
+    const colors = CALENDAR_COLOR_PRESETS.map((c, i) => getCalendarColor(i));
+    expect(colors).toEqual(CALENDAR_COLOR_PRESETS);
   });
 
-  it('handles a 5th+ family member without throwing (documented open question from the design plan)', () => {
-    // The design ADR flagged "does 4 categories cover 5+ family members" as
-    // an open question. It doesn't crash — it wraps — but a household with
-    // 5 members WILL get two people sharing a calendar color. This test
-    // documents that current behavior explicitly, so a future fix to
-    // support more distinct colors doesn't silently change this contract
-    // without someone noticing.
-    const colorsForFiveMembers = [0, 1, 2, 3, 4].map(getCalendarColor);
-    expect(colorsForFiveMembers[4]).toBe(colorsForFiveMembers[0]);
+  it('wraps only past the preset count', () => {
+    const count = CALENDAR_COLOR_PRESETS.length;
+    expect(getCalendarColor(count)).toBe(getCalendarColor(0));
+    expect(getCalendarColor(count + 1)).toBe(getCalendarColor(1));
+  });
+});
+
+describe('CALENDAR_COLOR_PRESETS', () => {
+  it('offers more than the 4 category colors so many calendars stay distinct', () => {
+    expect(CALENDAR_COLOR_PRESETS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('has no duplicate swatches', () => {
+    expect(new Set(CALENDAR_COLOR_PRESETS).size).toBe(CALENDAR_COLOR_PRESETS.length);
+  });
+
+  it('contains the four auto-assigned category colors', () => {
+    const categoryValues = Object.values(CALENDAR_COLORS);
+    for (const c of categoryValues) {
+      expect(CALENDAR_COLOR_PRESETS).toContain(c);
+    }
   });
 });
 
@@ -109,5 +120,20 @@ describe('resolveCalendarColor', () => {
 
   it('works with no options at all (plain positional fallback)', () => {
     expect(resolveCalendarColor('calendar.x', 2)).toBe(getCalendarColor(2));
+  });
+
+  it('falls back to defaultColor instead of the positional palette when provided', () => {
+    const color = resolveCalendarColor('beacon-local', 0, {
+      defaultColor: '#6366f1',
+    });
+    expect(color).toBe('#6366f1');
+  });
+
+  it('still lets a user override beat defaultColor', () => {
+    const color = resolveCalendarColor('beacon-local', 0, {
+      calendarColors: { 'beacon-local': '#ff6600' },
+      defaultColor: '#6366f1',
+    });
+    expect(color).toBe('#ff6600');
   });
 });

--- a/beacon/src/types.ts
+++ b/beacon/src/types.ts
@@ -7,6 +7,7 @@ export interface CalendarEvent {
   end: string;
   allDay: boolean;
   description?: string;
+  location?: string;
   calendarId: string;
   calendarName: string;
   color: string;

--- a/beacon/src/types.ts
+++ b/beacon/src/types.ts
@@ -57,8 +57,25 @@ export const CALENDAR_COLORS: Record<number, string> = {
   3: '#14b8a6', // teal
 };
 
+/* Picker swatches, also the positional auto-assignment order (first four keep
+   the original category colors; extra hues stop early collisions). */
+export const CALENDAR_COLOR_PRESETS: string[] = [
+  '#10b981', // sage    (category)
+  '#8b5cf6', // lavender (category)
+  '#f97316', // coral   (category)
+  '#14b8a6', // teal    (category)
+  '#3b82f6', // blue
+  '#6366f1', // indigo
+  '#ef4444', // red
+  '#f43f5e', // rose
+  '#ec4899', // pink
+  '#a855f7', // purple
+  '#eab308', // yellow
+  '#22c55e', // green
+];
+
 export function getCalendarColor(index: number): string {
-  return CALENDAR_COLORS[index % Object.keys(CALENDAR_COLORS).length];
+  return CALENDAR_COLOR_PRESETS[index % CALENDAR_COLOR_PRESETS.length];
 }
 
 /**
@@ -73,14 +90,9 @@ export interface CalendarColorMember {
 }
 
 /**
- * Resolves the display color for a calendar entity, in priority order:
- *   1. User-customized color (Settings > Calendar color picker)
- *   2. The color of the family member this calendar is linked to
- *      (via calendar_entity or additional_calendar_entities)
- *   3. The positional palette fallback (getCalendarColor(index))
- *
- * This is the single source of truth for calendar/event color so the
- * Dashboard and Calendar (WeekCalendar) views never disagree.
+ * Picks a calendar's display color: user override > linked family member >
+ * defaultColor > positional preset. Single source of truth so every view
+ * (Dashboard, Calendar, Settings) agrees.
  */
 export function resolveCalendarColor(
   calendarId: string,
@@ -88,6 +100,7 @@ export function resolveCalendarColor(
   options?: {
     calendarColors?: Record<string, string>;
     members?: CalendarColorMember[];
+    defaultColor?: string;
   },
 ): string {
   const userColor = options?.calendarColors?.[calendarId];
@@ -101,7 +114,7 @@ export function resolveCalendarColor(
   );
   if (linkedMember?.color) return linkedMember.color;
 
-  return getCalendarColor(index);
+  return options?.defaultColor ?? getCalendarColor(index);
 }
 
 /* Maps a full-saturation calendar color to its pastel variant for event blocks */

--- a/docs-site/src/content/docs/features/calendar.mdx
+++ b/docs-site/src/content/docs/features/calendar.mdx
@@ -20,7 +20,7 @@ The calendar view shows 7 days starting from Sunday of the current week. The lay
 - **Current time indicator**: A colored horizontal line on today's column showing the current time
 - **Auto-scroll**: On load, the grid scrolls to show the current hour near the top
 
-Events are color-coded by calendar. Each calendar is assigned a color from the palette (blue, green, purple, orange, pink, teal) based on the order it was discovered.
+Events are color-coded by calendar. Each calendar is assigned a color from a 12-color preset palette based on the order it was discovered (the first four keep the classic category colors). Colors only cycle once you have more than 12 calendars, and every calendar can be re-colored individually in **Settings → Calendar**.
 
 ---
 
@@ -165,18 +165,24 @@ For a single all-day event, set the start and end date to the same day. For a mu
 
 ## Family member color coding
 
-Each calendar discovered by Beacon is assigned a color from the palette:
+Each calendar discovered by Beacon is assigned a color from the palette, in discovery order:
 
 | Position | Color | Hex |
 |----------|-------|-----|
-| 1st calendar | Blue | `#3b82f6` |
-| 2nd calendar | Green | `#22c55e` |
-| 3rd calendar | Purple | `#a855f7` |
-| 4th calendar | Orange | `#f97316` |
-| 5th calendar | Pink | `#ec4899` |
-| 6th calendar | Teal | `#14b8a6` |
+| 1st calendar | Sage | `#10b981` |
+| 2nd calendar | Lavender | `#8b5cf6` |
+| 3rd calendar | Coral | `#f97316` |
+| 4th calendar | Teal | `#14b8a6` |
+| 5th calendar | Blue | `#3b82f6` |
+| 6th calendar | Indigo | `#6366f1` |
+| 7th calendar | Red | `#ef4444` |
+| 8th calendar | Rose | `#f43f5e` |
+| 9th calendar | Pink | `#ec4899` |
+| 10th calendar | Purple | `#a855f7` |
+| 11th calendar | Yellow | `#eab308` |
+| 12th calendar | Green | `#22c55e` |
 
-Colors cycle if you have more than 6 calendars.
+The first four positions match Beacon's original category colors, so existing setups keep their colors. Colors cycle if you have more than 12 calendars. To change any calendar's color (including the built-in Beacon calendar), open **Settings → Calendar**, click the color dot, and pick a preset swatch or a custom color.
 
 Event blocks use a **pastel** version of the calendar color as the background and the **full** color as a left-side stripe, making events easy to distinguish at a glance.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { startOfWeek, startOfDay, addDays, format } from 'date-fns';
 import { useHomeAssistant } from './hooks/useHomeAssistant';
 import { useCalendarEvents, CalendarNotSupportedError } from './hooks/useCalendarEvents';
@@ -232,7 +232,22 @@ export function App() {
     }, 5 * 60 * 1000);
 
     return () => clearInterval(interval);
-  }, [connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart, settings.calendarColors, members]);
+  }, [connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart]);
+
+  // Re-fetch when calendar colors or family members change so colors update
+  // immediately, without recreating the 5-minute polling interval above.
+  const colorRefreshRef = useRef({ connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart });
+  colorRefreshRef.current = { connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart };
+  const didColorRefreshMount = useRef(false);
+  useEffect(() => {
+    if (!didColorRefreshMount.current) {
+      didColorRefreshMount.current = true;
+      return;
+    }
+    if (!colorRefreshRef.current.connected) return;
+    colorRefreshRef.current.fetchCalendars();
+    colorRefreshRef.current.refetchEventsForWeek(colorRefreshRef.current.visibleWeekStart);
+  }, [settings.calendarColors, members]);
 
   const handleToggleCalendar = useCallback((calendarId: string) => {
     setHiddenCalendars(prev => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ import { useDashboardTasks } from './hooks/useDashboardTasks';
 import OnboardingView from './components/OnboardingView';
 import { FocusView } from './components/focus/FocusView';
 import { getFocusMemberId, clearFocusMode, setDeviceFocusMember } from './focus';
-import { CalendarEvent } from './types';
+import { CalendarEvent, resolveCalendarColor } from './types';
 import { getConfig, patchConfig } from './config';
 
 const config = getConfig();
@@ -74,14 +74,23 @@ export function App() {
 
   const localCal = useLocalCalendar();
 
+  // Resolve the local calendar's color the same way everywhere (user override or indigo default).
+  const localCalendarColor = resolveCalendarColor(localCal.calendar.id, 0, {
+    calendarColors: settings.calendarColors,
+    defaultColor: localCal.calendar.color,
+  });
+
   // Merge HA + local calendars and events
   const calendars = useMemo(
-    () => [localCal.calendar, ...haCalendars],
-    [localCal.calendar, haCalendars],
+    () => [{ ...localCal.calendar, color: localCalendarColor }, ...haCalendars],
+    [localCal.calendar, localCalendarColor, haCalendars],
   );
   const events = useMemo(
-    () => [...localCal.events, ...haEvents].sort((a, b) => a.start.localeCompare(b.start)),
-    [localCal.events, haEvents],
+    () => [
+      ...localCal.events.map((ev) => ({ ...ev, color: localCalendarColor })),
+      ...haEvents,
+    ].sort((a, b) => a.start.localeCompare(b.start)),
+    [localCal.events, localCalendarColor, haEvents],
   );
 
   // Route create/update/delete to local or HA based on calendar ID
@@ -223,7 +232,7 @@ export function App() {
     }, 5 * 60 * 1000);
 
     return () => clearInterval(interval);
-  }, [connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart]);
+  }, [connected, fetchCalendars, refetchEventsForWeek, visibleWeekStart, settings.calendarColors, members]);
 
   const handleToggleCalendar = useCallback((calendarId: string) => {
     setHiddenCalendars(prev => {

--- a/src/api/homeassistant.ts
+++ b/src/api/homeassistant.ts
@@ -206,6 +206,7 @@ export class HomeAssistantClient {
       start: string | { dateTime: string; date: string };
       end: string | { dateTime: string; date: string };
       description?: string;
+      location?: string;
       recurrence_id?: string;
     }>;
 
@@ -223,6 +224,7 @@ export class HomeAssistantClient {
         end: endStr,
         allDay,
         description: ev.description,
+        location: ev.location,
         calendarId,
         calendarName: calendarId,
         color: '', // will be set by consumer

--- a/src/components/EventBlock.tsx
+++ b/src/components/EventBlock.tsx
@@ -46,7 +46,7 @@ export function EventBlock({ event, onClick, style, allDay, multiDay, draggable,
       }}
       onClick={(e) => onClick(event, e)}
       type="button"
-      title={`${event.title} (${timeLabel})`}
+      title={`${event.title}${event.location ? ` — ${event.location}` : ''} (${timeLabel})`}
       draggable={draggable}
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
@@ -55,6 +55,9 @@ export function EventBlock({ event, onClick, style, allDay, multiDay, draggable,
       <div className="event-block-stripe" style={{ backgroundColor: full }} />
       <div className="event-block-content">
         <span className="event-block-title">{event.title}</span>
+        {event.location && (
+          <span className="event-block-location">{event.location}</span>
+        )}
         {!allDay && (
           <span className="event-block-time">{timeLabel}</span>
         )}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -28,6 +28,7 @@ export function EventCard({ event, onClick }: EventCardProps) {
     >
       <span className="event-card-calendar">{event.calendarName}</span>
       <span className="event-card-title">{event.title}</span>
+      {event.location && <span className="event-card-location">{event.location}</span>}
       <span className="event-card-time">{timeLabel}</span>
     </div>
   );

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -17,10 +17,16 @@ import {
 import { AnyListClient } from '../api/anylist';
 import { GroceryList } from '../types/grocery';
 import { themes } from '../styles/themes';
-import { FamilyMember, MEMBER_COLORS, AVATAR_CATEGORIES, Routine } from '../types/family';
+import {
+  FamilyMember,
+  MEMBER_COLORS,
+  AVATAR_CATEGORIES,
+  Routine,
+} from '../types/family';
 import type { BeaconSettings } from '../hooks/useSettings';
 import { buildFocusUrl } from '../focus';
 import { useRoutines } from '../hooks/useRoutines';
+import { resolveCalendarColor, CALENDAR_COLOR_PRESETS } from '../types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -52,7 +58,7 @@ interface SettingsViewProps {
   connected: boolean;
   haUrl: string;
   // Calendars
-  calendars: Array<{ id: string; name: string }>;
+  calendars: Array<{ id: string; name: string; color?: string }>;
   // Kid Display
   onEnterFocusMode: (memberId: string) => void;
 }
@@ -206,6 +212,7 @@ export function SettingsView({
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [kidDisplayMemberId, setKidDisplayMemberId] = useState('');
   const [copiedFocusUrl, setCopiedFocusUrl] = useState(false);
+  const [colorEditId, setColorEditId] = useState<string | null>(null);
 
   // ---- Routine editor state ----
   const routinesApi = useRoutines();
@@ -1128,45 +1135,99 @@ export function SettingsView({
             </div>
           </div>
         ) : (
-          calendars.map((cal) => {
+          calendars.map((cal, index) => {
             const isHidden = settings.permanentlyHiddenCalendars.includes(cal.id);
-            const color = settings.calendarColors[cal.id] || '';
+            const customColor = settings.calendarColors[cal.id] || '';
+            const resolvedColor = resolveCalendarColor(cal.id, index, {
+              calendarColors: settings.calendarColors,
+              members,
+              defaultColor: cal.color,
+            });
+            const open = colorEditId === cal.id;
+
+            const setColor = (value: string) => {
+              onUpdateSettings({
+                calendarColors: { ...settings.calendarColors, [cal.id]: value },
+              });
+            };
+            const resetColor = () => {
+              const next = { ...settings.calendarColors };
+              delete next[cal.id];
+              onUpdateSettings({ calendarColors: next });
+            };
+
             return (
-              <div key={cal.id} className="settings-row">
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
-                  <input
-                    type="color"
-                    value={color || '#3b82f6'}
-                    onChange={(e) => {
-                      onUpdateSettings({
-                        calendarColors: { ...settings.calendarColors, [cal.id]: e.target.value },
-                      });
-                    }}
+              <div key={cal.id} className="settings-calendar-row">
+                <div className="settings-row">
+                  <div
                     style={{
-                      width: 24,
-                      height: 24,
-                      borderRadius: '50%',
-                      border: '1px solid var(--border)',
-                      cursor: 'pointer',
-                      padding: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      flex: 1,
+                      minWidth: 0,
                     }}
-                    title="Calendar color"
-                  />
-                  <div>
-                    <div className="settings-row-label">{cal.name}</div>
-                    <div className="settings-row-sublabel">{cal.id}</div>
+                  >
+                    <button
+                      type="button"
+                      className="settings-calendar-color-swatch"
+                      style={{ backgroundColor: resolvedColor }}
+                      onClick={() => setColorEditId(open ? null : cal.id)}
+                      title="Edit calendar color"
+                      aria-label={`Edit color for ${cal.name}`}
+                      aria-expanded={open}
+                    />
+                    <div style={{ minWidth: 0 }}>
+                      <div className="settings-row-label">{cal.name}</div>
+                      <div className="settings-row-sublabel">{cal.id}</div>
+                    </div>
                   </div>
+                  <Toggle
+                    checked={!isHidden}
+                    onChange={(visible) => {
+                      const hidden = settings.permanentlyHiddenCalendars.filter(
+                        (id) => id !== cal.id,
+                      );
+                      if (!visible) hidden.push(cal.id);
+                      onUpdateSettings({ permanentlyHiddenCalendars: hidden });
+                    }}
+                  />
                 </div>
-                <Toggle
-                  checked={!isHidden}
-                  onChange={(visible) => {
-                    const hidden = settings.permanentlyHiddenCalendars.filter(
-                      (id) => id !== cal.id,
-                    );
-                    if (!visible) hidden.push(cal.id);
-                    onUpdateSettings({ permanentlyHiddenCalendars: hidden });
-                  }}
-                />
+                {open && (
+                  <div className="settings-color-editor">
+                    <div className="settings-color-grid">
+                      {CALENDAR_COLOR_PRESETS.map((preset) => (
+                        <button
+                          key={preset}
+                          type="button"
+                          className={`settings-color-circle ${customColor === preset ? 'settings-color-circle--selected' : ''}`}
+                          style={{ backgroundColor: preset }}
+                          onClick={() => setColor(preset)}
+                          aria-label={`Set ${cal.name} to ${preset}`}
+                        />
+                      ))}
+                    </div>
+                    <div className="settings-color-editor-custom">
+                      <label className="settings-color-custom">
+                        <input
+                          type="color"
+                          value={customColor || resolvedColor}
+                          onChange={(e) => setColor(e.target.value)}
+                          aria-label={`Choose a custom color for ${cal.name}`}
+                        />
+                        <span>Custom…</span>
+                      </label>
+                      <button
+                        type="button"
+                        className="settings-btn"
+                        onClick={resetColor}
+                        disabled={!customColor}
+                      >
+                        Reset to auto
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             );
           })

--- a/src/hooks/useCalendarEvents.ts
+++ b/src/hooks/useCalendarEvents.ts
@@ -88,6 +88,7 @@ export function useCalendarEvents(
             start: string | { dateTime: string; date: string };
             end: string | { dateTime: string; date: string };
             description?: string;
+            location?: string;
             recurrence_id?: string;
           }>;
 
@@ -112,6 +113,7 @@ export function useCalendarEvents(
               end: endStr,
               allDay,
               description: ev.description,
+              location: ev.location,
               calendarId: cal.id,
               calendarName: cal.name,
               color: cal.color,

--- a/src/styles/beacon.css
+++ b/src/styles/beacon.css
@@ -1073,6 +1073,16 @@ a:focus:not(:focus-visible) {
   line-height: 1.2;
 }
 
+.event-block-location {
+  font-size: 0.65rem;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.55);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
 /* All-day event blocks */
 .event-block--allday {
   position: relative;
@@ -1883,6 +1893,10 @@ a:focus:not(:focus-visible) {
   }
 
   .event-block-time {
+    display: none;
+  }
+
+  .event-block-location {
     display: none;
   }
 

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -478,10 +478,19 @@
   color: rgba(0, 0, 0, 0.5);
 }
 
+.event-card-location {
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.5);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 [data-theme="dark"] .event-card { box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3); }
 [data-theme="dark"] .event-card-calendar { color: rgba(0, 0, 0, 0.5); }
 [data-theme="dark"] .event-card-title { color: rgba(0, 0, 0, 0.85); }
 [data-theme="dark"] .event-card-time { color: rgba(0, 0, 0, 0.5); }
+[data-theme="dark"] .event-card-location { color: rgba(0, 0, 0, 0.5); }
 
 /* --- Task Checklist --- */
 .task-checklist {

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -427,6 +427,74 @@
   box-shadow: 0 0 0 2px var(--bg-surface), 0 0 0 4px var(--text-primary);
 }
 
+/* --- Per-calendar color editor --- */
+.settings-calendar-row {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.settings-calendar-row:last-child {
+  border-bottom: none;
+}
+
+.settings-calendar-color-swatch {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid var(--bg-surface);
+  box-shadow: 0 0 0 1px var(--border);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--transition);
+}
+
+.settings-calendar-color-swatch:hover {
+  transform: scale(1.12);
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+.settings-color-editor {
+  border-top: 1px dashed var(--border-subtle);
+  background: color-mix(in srgb, var(--bg-surface) 55%, transparent);
+  padding: 12px 0 16px;
+}
+
+.settings-color-editor .settings-color-grid {
+  padding: 0 20px 12px;
+}
+
+.settings-color-editor-custom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 20px;
+  flex-wrap: wrap;
+}
+
+.settings-color-custom {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.settings-color-custom input[type="color"] {
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  cursor: pointer;
+  background: none;
+}
+
+.settings-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 /* --- Button styles for settings --- */
 .settings-btn {
   padding: 8px 18px;

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   CALENDAR_COLORS,
+  CALENDAR_COLOR_PRESETS,
   getCalendarColor,
   getPastelColor,
   getFullColor,
@@ -26,26 +27,36 @@ describe('CALENDAR_COLORS', () => {
 });
 
 describe('getCalendarColor', () => {
-  it('returns the color at the given index', () => {
-    expect(getCalendarColor(0)).toBe(CALENDAR_COLORS[0]);
-    expect(getCalendarColor(1)).toBe(CALENDAR_COLORS[1]);
+  it('keeps the original category colors for the first four calendars', () => {
+    expect([0, 1, 2, 3].map(getCalendarColor)).toEqual(Object.values(CALENDAR_COLORS));
   });
 
-  it('wraps around via modulo once index exceeds the category count', () => {
-    // 4 categories, so index 4 should wrap back to index 0's color
-    expect(getCalendarColor(4)).toBe(getCalendarColor(0));
-    expect(getCalendarColor(5)).toBe(getCalendarColor(1));
+  it('walks the full preset palette before wrapping (no early collisions)', () => {
+    const colors = CALENDAR_COLOR_PRESETS.map((c, i) => getCalendarColor(i));
+    expect(colors).toEqual(CALENDAR_COLOR_PRESETS);
   });
 
-  it('handles a 5th+ family member without throwing (documented open question from the design plan)', () => {
-    // The design ADR flagged "does 4 categories cover 5+ family members" as
-    // an open question. It doesn't crash — it wraps — but a household with
-    // 5 members WILL get two people sharing a calendar color. This test
-    // documents that current behavior explicitly, so a future fix to
-    // support more distinct colors doesn't silently change this contract
-    // without someone noticing.
-    const colorsForFiveMembers = [0, 1, 2, 3, 4].map(getCalendarColor);
-    expect(colorsForFiveMembers[4]).toBe(colorsForFiveMembers[0]);
+  it('wraps only past the preset count', () => {
+    const count = CALENDAR_COLOR_PRESETS.length;
+    expect(getCalendarColor(count)).toBe(getCalendarColor(0));
+    expect(getCalendarColor(count + 1)).toBe(getCalendarColor(1));
+  });
+});
+
+describe('CALENDAR_COLOR_PRESETS', () => {
+  it('offers more than the 4 category colors so many calendars stay distinct', () => {
+    expect(CALENDAR_COLOR_PRESETS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('has no duplicate swatches', () => {
+    expect(new Set(CALENDAR_COLOR_PRESETS).size).toBe(CALENDAR_COLOR_PRESETS.length);
+  });
+
+  it('contains the four auto-assigned category colors', () => {
+    const categoryValues = Object.values(CALENDAR_COLORS);
+    for (const c of categoryValues) {
+      expect(CALENDAR_COLOR_PRESETS).toContain(c);
+    }
   });
 });
 
@@ -109,5 +120,20 @@ describe('resolveCalendarColor', () => {
 
   it('works with no options at all (plain positional fallback)', () => {
     expect(resolveCalendarColor('calendar.x', 2)).toBe(getCalendarColor(2));
+  });
+
+  it('falls back to defaultColor instead of the positional palette when provided', () => {
+    const color = resolveCalendarColor('beacon-local', 0, {
+      defaultColor: '#6366f1',
+    });
+    expect(color).toBe('#6366f1');
+  });
+
+  it('still lets a user override beat defaultColor', () => {
+    const color = resolveCalendarColor('beacon-local', 0, {
+      calendarColors: { 'beacon-local': '#ff6600' },
+      defaultColor: '#6366f1',
+    });
+    expect(color).toBe('#ff6600');
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface CalendarEvent {
   end: string;
   allDay: boolean;
   description?: string;
+  location?: string;
   calendarId: string;
   calendarName: string;
   color: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,8 +57,25 @@ export const CALENDAR_COLORS: Record<number, string> = {
   3: '#14b8a6', // teal
 };
 
+/* Picker swatches, also the positional auto-assignment order (first four keep
+   the original category colors; extra hues stop early collisions). */
+export const CALENDAR_COLOR_PRESETS: string[] = [
+  '#10b981', // sage    (category)
+  '#8b5cf6', // lavender (category)
+  '#f97316', // coral   (category)
+  '#14b8a6', // teal    (category)
+  '#3b82f6', // blue
+  '#6366f1', // indigo
+  '#ef4444', // red
+  '#f43f5e', // rose
+  '#ec4899', // pink
+  '#a855f7', // purple
+  '#eab308', // yellow
+  '#22c55e', // green
+];
+
 export function getCalendarColor(index: number): string {
-  return CALENDAR_COLORS[index % Object.keys(CALENDAR_COLORS).length];
+  return CALENDAR_COLOR_PRESETS[index % CALENDAR_COLOR_PRESETS.length];
 }
 
 /**
@@ -73,14 +90,9 @@ export interface CalendarColorMember {
 }
 
 /**
- * Resolves the display color for a calendar entity, in priority order:
- *   1. User-customized color (Settings > Calendar color picker)
- *   2. The color of the family member this calendar is linked to
- *      (via calendar_entity or additional_calendar_entities)
- *   3. The positional palette fallback (getCalendarColor(index))
- *
- * This is the single source of truth for calendar/event color so the
- * Dashboard and Calendar (WeekCalendar) views never disagree.
+ * Picks a calendar's display color: user override > linked family member >
+ * defaultColor > positional preset. Single source of truth so every view
+ * (Dashboard, Calendar, Settings) agrees.
  */
 export function resolveCalendarColor(
   calendarId: string,
@@ -88,6 +100,7 @@ export function resolveCalendarColor(
   options?: {
     calendarColors?: Record<string, string>;
     members?: CalendarColorMember[];
+    defaultColor?: string;
   },
 ): string {
   const userColor = options?.calendarColors?.[calendarId];
@@ -101,7 +114,7 @@ export function resolveCalendarColor(
   );
   if (linkedMember?.color) return linkedMember.color;
 
-  return getCalendarColor(index);
+  return options?.defaultColor ?? getCalendarColor(index);
 }
 
 /* Maps a full-saturation calendar color to its pastel variant for event blocks */


### PR DESCRIPTION
- Added a larger color palette to reduce the chance of color collisions. Original colors were preserved for backward compatibility.
- In settings, show the calendar's color rather than the default blue.
- Allow resetting to auto-coloring once a color has been set.
- Added location when available

<img width="231" height="109" alt="image" src="https://github.com/user-attachments/assets/4bc5dc14-f236-4549-9a69-535b0a75557e" />
<img width="623" height="196" alt="image" src="https://github.com/user-attachments/assets/ff33b30d-f042-4153-85d2-8a2c1069eb29" />
<img width="458" height="426" alt="image" src="https://github.com/user-attachments/assets/5af71120-3ea0-498f-9264-d358f55155f0" />

Showing location when it's available on calendar event:
<img width="81" height="60" alt="image" src="https://github.com/user-attachments/assets/d8a5f044-6a72-442d-9a89-07b0bc3b7ea8" />
<img width="221" height="111" alt="image" src="https://github.com/user-attachments/assets/bb0d2d72-ecc9-4464-9127-2771889a7bab" />
