### PR TITLE
Google calendar overlap view and gray out past events on dashboard

### DIFF
--- a/beacon/src/components/DashboardView.tsx
+++ b/beacon/src/components/DashboardView.tsx
@@ -102,8 +102,9 @@ export function DashboardView({
   }, [events, selectedDate]);
 
   // Group the next 7 days of events for the Classic "This Week" column
+  // (starts tomorrow — today is covered by the Today column)
   const weekEvents = useMemo(() => {
-    const start = startOfDay(new Date());
+    const start = addDays(startOfDay(new Date()), 1);
     return Array.from({ length: 7 }, (_, i) => {
       const day = addDays(start, i);
       const dayEvents = events

--- a/beacon/src/components/EventBlock.tsx
+++ b/beacon/src/components/EventBlock.tsx
@@ -16,6 +16,7 @@ interface EventBlockProps {
 export function EventBlock({ event, onClick, style, allDay, multiDay, draggable, expanded, onDragStart, onDragEnd }: EventBlockProps) {
   const pastel = getPastelColor(event.color);
   const full = getFullColor(event.color);
+  const isPast = parseISO(event.end).getTime() < Date.now();
 
   const timeLabel = event.allDay
     ? 'All day'
@@ -26,7 +27,7 @@ export function EventBlock({ event, onClick, style, allDay, multiDay, draggable,
   if (multiDay) {
     return (
       <div
-        className="event-block-inner event-block-inner--multiday"
+        className={`event-block-inner event-block-inner--multiday ${isPast ? 'event-block--past' : ''}`}
         style={{ backgroundColor: pastel }}
       >
         <div className="event-block-stripe" style={{ backgroundColor: full }} />
@@ -39,7 +40,7 @@ export function EventBlock({ event, onClick, style, allDay, multiDay, draggable,
 
   return (
     <button
-      className={`event-block ${allDay ? 'event-block--allday' : ''} ${draggable ? 'event-block--draggable' : ''} ${expanded ? 'event-block--expanded' : ''}`}
+      className={`event-block ${allDay ? 'event-block--allday' : ''} ${draggable ? 'event-block--draggable' : ''} ${expanded ? 'event-block--expanded' : ''} ${isPast ? 'event-block--past' : ''}`}
       style={{
         ...style,
         backgroundColor: pastel,

--- a/beacon/src/components/EventCard.test.tsx
+++ b/beacon/src/components/EventCard.test.tsx
@@ -61,4 +61,23 @@ describe('EventCard', () => {
     await user.click(card);
     expect(onClick).toHaveBeenCalledWith(event);
   });
+
+  it('grays out events that have already ended', () => {
+    const { container } = render(<EventCard event={makeEvent()} />);
+    expect(container.querySelector('.event-card')).toHaveClass('event-card--past');
+  });
+
+  it('keeps future-dated events un-grayed even when their clock time is early', () => {
+    const { container } = render(
+      <EventCard event={makeEvent({ start: '2999-01-01T08:00:00', end: '2999-01-01T09:00:00' })} />,
+    );
+    expect(container.querySelector('.event-card')).not.toHaveClass('event-card--past');
+  });
+
+  it('keeps future all-day events un-grayed (bare-date end parsed as a locale date)', () => {
+    const { container } = render(
+      <EventCard event={makeEvent({ allDay: true, start: '2999-01-01', end: '2999-01-02' })} />,
+    );
+    expect(container.querySelector('.event-card')).not.toHaveClass('event-card--past');
+  });
 });

--- a/beacon/src/components/EventCard.tsx
+++ b/beacon/src/components/EventCard.tsx
@@ -9,6 +9,7 @@ interface EventCardProps {
 export function EventCard({ event, onClick }: EventCardProps) {
   const pastel = getPastelColor(event.color);
   const full = getFullColor(event.color);
+  const isPast = parseISO(event.end).getTime() < Date.now();
 
   const timeLabel = event.allDay
     ? 'All day'
@@ -16,7 +17,7 @@ export function EventCard({ event, onClick }: EventCardProps) {
 
   return (
     <div
-      className={`event-card ${onClick ? 'event-card--clickable' : ''}`}
+      className={`event-card ${onClick ? 'event-card--clickable' : ''} ${isPast ? 'event-card--past' : ''}`}
       style={{
         backgroundColor: pastel,
         borderLeft: `4px solid ${full}`,

--- a/beacon/src/components/WeekCalendar.tsx
+++ b/beacon/src/components/WeekCalendar.tsx
@@ -11,6 +11,7 @@ import {
   getMinutes,
 } from 'date-fns';
 import { CalendarEvent } from '../types';
+import { computeOverlapLayout, type OverlapLayout } from '../utils/overlap-layout';
 import { EventBlock } from './EventBlock';
 import { EventDetailsPopover } from './EventDetailsPopover';
 import { useWeatherForecast } from '../hooks/useWeatherForecast';
@@ -331,67 +332,8 @@ export function WeekCalendar({ events, hiddenCalendars, onEventClick, onSlotClic
 
   const isCurrentWeek = weekOffset === 0;
 
-  // Compute overlap layout for a list of events in one day column.
-  // Returns a map of eventId → { column, totalColumns } for side-by-side rendering.
-  function computeOverlapLayout(dayEvents: CalendarEvent[]): Map<string, { col: number; total: number }> {
-    const result = new Map<string, { col: number; total: number }>();
-    if (dayEvents.length === 0) return result;
-
-    // Sort by start time, then longer events first
-    const sorted = [...dayEvents].sort((a, b) => {
-      const cmp = a.start.localeCompare(b.start);
-      if (cmp !== 0) return cmp;
-      return b.end.localeCompare(a.end);
-    });
-
-    // Groups of overlapping events
-    const groups: CalendarEvent[][] = [];
-    let currentGroup: CalendarEvent[] = [];
-    let currentGroupEnd = '';
-
-    for (const event of sorted) {
-      if (currentGroup.length === 0 || event.start < currentGroupEnd) {
-        currentGroup.push(event);
-        if (event.end > currentGroupEnd) currentGroupEnd = event.end;
-      } else {
-        groups.push(currentGroup);
-        currentGroup = [event];
-        currentGroupEnd = event.end;
-      }
-    }
-    if (currentGroup.length > 0) groups.push(currentGroup);
-
-    // Assign columns within each group
-    for (const group of groups) {
-      const columns: CalendarEvent[][] = [];
-      for (const event of group) {
-        let placed = false;
-        for (let c = 0; c < columns.length; c++) {
-          const lastInCol = columns[c][columns[c].length - 1];
-          if (event.start >= lastInCol.end) {
-            columns[c].push(event);
-            result.set(event.id, { col: c, total: 0 });
-            placed = true;
-            break;
-          }
-        }
-        if (!placed) {
-          columns.push([event]);
-          result.set(event.id, { col: columns.length - 1, total: 0 });
-        }
-      }
-      // Set total columns for the group
-      for (const event of group) {
-        const entry = result.get(event.id);
-        if (entry) entry.total = columns.length;
-      }
-    }
-
-    return result;
-  }
-
   // Calculate position and height for a timed event
-  function getEventStyle(event: CalendarEvent, layout?: { col: number; total: number }): React.CSSProperties {
+  function getEventStyle(event: CalendarEvent, layout?: OverlapLayout): React.CSSProperties {
     const start = parseISO(event.start);
     const end = parseISO(event.end);
     const startHour = getHours(start) + getMinutes(start) / 60;
@@ -409,10 +351,10 @@ export function WeekCalendar({ events, hiddenCalendars, onEventClick, onSlotClic
     };
 
     // Side-by-side columns for overlapping events
-    if (layout && layout.total > 1) {
-      const widthPct = 100 / layout.total;
-      style.left = `calc(${layout.col * widthPct}% + 1px)`;
-      style.width = `calc(${widthPct}% - 2px)`;
+    if (layout && layout.width < 1) {
+      style.left = `calc(${layout.left * 100}% + 1px)`;
+      style.width = `calc(${layout.width * 100}% - 2px)`;
+      style.zIndex = layout.level + 2;
     }
 
     return style;

--- a/beacon/src/styles/beacon.css
+++ b/beacon/src/styles/beacon.css
@@ -1042,6 +1042,12 @@ a:focus:not(:focus-visible) {
   transform: scale(0.99);
 }
 
+/* Events that have already ended are muted so upcoming ones stand out */
+.event-block--past {
+  opacity: 0.55;
+  filter: grayscale(0.6);
+}
+
 .event-block-stripe {
   width: 3px;
   flex-shrink: 0;

--- a/beacon/src/styles/beacon.css
+++ b/beacon/src/styles/beacon.css
@@ -1027,7 +1027,7 @@ a:focus:not(:focus-visible) {
   z-index: 1;
   display: flex;
   min-height: 22px;
-  border: none;
+  border: 1px solid #fff;
   text-align: left;
   padding: 0;
 }
@@ -1060,9 +1060,11 @@ a:focus:not(:focus-visible) {
   font-size: 0.75rem;
   font-weight: 600;
   color: rgba(0, 0, 0, 0.85);
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: break-word;
   line-height: 1.3;
 }
 

--- a/beacon/src/styles/dashboard.css
+++ b/beacon/src/styles/dashboard.css
@@ -457,6 +457,12 @@
   cursor: pointer;
 }
 
+/* Events that have already ended are muted so upcoming ones stand out */
+.event-card--past {
+  opacity: 0.6;
+  filter: grayscale(0.6);
+}
+
 .event-card-calendar {
   font-size: 11px;
   font-weight: 600;

--- a/beacon/src/utils/overlap-layout.test.ts
+++ b/beacon/src/utils/overlap-layout.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { computeOverlapLayout, type OverlapEvent } from './overlap-layout';
+
+const d = (time: string) => `2026-09-08T${time}:00`;
+
+function ev(id: string, start: string, end: string): OverlapEvent {
+  return { id, start: d(start), end: d(end) };
+}
+
+describe('computeOverlapLayout', () => {
+  it('returns an empty map when there are no events', () => {
+    expect(computeOverlapLayout([]).size).toBe(0);
+  });
+
+  it('emits no layout for non-overlapping events', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '10:00'),
+      ev('b', '10:00', '11:00'),
+      ev('c', '13:00', '14:00'),
+    ]);
+    expect(layout.size).toBe(0);
+  });
+
+  it('spans the first of two overlaps full-width behind the second', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '11:00'),
+      ev('b', '10:00', '12:00'),
+    ]);
+    // a doubles to full width → omitted (CSS default already means full width)
+    expect(layout.get('a')).toBeUndefined();
+    // b doubles onto the right half
+    expect(layout.get('b')!.left).toBeCloseTo(0.5);
+    expect(layout.get('b')!.width).toBeCloseTo(0.5);
+    expect(layout.get('b')!.level).toBe(1);
+  });
+
+  it('extends the first two of three overlapping events behind', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '11:00'),
+      ev('b', '09:30', '10:30'),
+      ev('c', '10:00', '11:00'),
+    ]);
+    // raw thirds a(0,1/3) b(1/3,2/3) c(2/3,1); doubled → a,b 2/3, c 1/3
+    expect(layout.get('a')!.left).toBeCloseTo(0);
+    expect(layout.get('a')!.width).toBeCloseTo(2 / 3);
+    expect(layout.get('b')!.left).toBeCloseTo(1 / 3);
+    expect(layout.get('b')!.width).toBeCloseTo(2 / 3);
+    expect(layout.get('c')!.left).toBeCloseTo(2 / 3);
+    expect(layout.get('c')!.width).toBeCloseTo(1 / 3);
+  });
+
+  it('lets a long event span full width while two short events sit right', () => {
+    const layout = computeOverlapLayout([
+      ev('long', '09:00', '17:00'),
+      ev('s1', '10:00', '11:00'),
+      ev('s2', '12:00', '13:00'),
+    ]);
+    expect(layout.get('long')).toBeUndefined();
+    expect(layout.get('s1')!.left).toBeCloseTo(0.5);
+    expect(layout.get('s1')!.width).toBeCloseTo(0.5);
+    expect(layout.get('s2')!.left).toBeCloseTo(0.5);
+    expect(layout.get('s2')!.width).toBeCloseTo(0.5);
+  });
+
+  it('keeps a low-competition event wider than the cluster it joins', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '17:00'),
+      ev('b', '10:00', '12:00'),
+      ev('c', '11:00', '13:00'),
+      ev('d', '14:00', '15:00'),
+    ]);
+    // d only overlaps a, so it spans the two right columns
+    expect(layout.get('a')!.left).toBeCloseTo(0);
+    expect(layout.get('b')!.left).toBeCloseTo(1 / 3);
+    expect(layout.get('c')!.left).toBeCloseTo(2 / 3);
+    expect(layout.get('d')!.left).toBeCloseTo(1 / 3);
+    expect(layout.get('d')!.width).toBeCloseTo(2 / 3);
+  });
+
+  it('keeps all layout fractions within the day column', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '18:00'),
+      ev('b', '09:30', '10:30'),
+      ev('c', '10:00', '12:00'),
+      ev('d', '11:30', '13:00'),
+      ev('e', '12:30', '14:30'),
+      ev('f', '14:00', '16:00'),
+    ]);
+    for (const [id, l] of layout) {
+      expect(l.left, id).toBeGreaterThanOrEqual(0);
+      expect(l.width, id).toBeGreaterThan(0);
+      expect(l.left + l.width, id).toBeLessThanOrEqual(1 + 1e-9);
+    }
+  });
+
+  it('assigns increasing levels for stacked columns', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '12:00'),
+      ev('b', '09:30', '11:30'),
+      ev('c', '10:00', '11:00'),
+    ]);
+    const levels = [layout.get('a')!.level, layout.get('b')!.level, layout.get('c')!.level];
+    expect(levels).toEqual([0, 1, 2]);
+  });
+});

--- a/beacon/src/utils/overlap-layout.ts
+++ b/beacon/src/utils/overlap-layout.ts
@@ -1,0 +1,132 @@
+/**
+ * Side-by-side layout for timed events sharing one day column.
+ * Port of FullCalendar v4 TimeGridEventRenderer's overlap algorithm
+ * (matches Google Calendar's visual style).
+ */
+
+export interface OverlapEvent {
+  id: string;
+  /** ISO 8601 datetime — lexicographic order matches chronological order */
+  start: string;
+  end: string;
+}
+
+export interface OverlapLayout {
+  /** Left edge as a 0–1 fraction of the day column width */
+  left: number;
+  /** Width as a 0–1 fraction of the day column width */
+  width: number;
+  /** Column level (0-based); higher = drawn on top */
+  level: number;
+}
+
+interface Seg {
+  id: string;
+  top: number; // minutes from midnight
+  bottom: number; // minutes from midnight
+  level: number;
+  forwardSegs: Seg[]; // segs in deeper levels that overlap this one
+  forwardPressure: number; // memoised longest forward-chain depth
+  backwardCoord: number; // left edge 0–1
+  forwardCoord: number; // right edge 0–1
+}
+
+// Coords are always 0–1, so NaN marks "not yet computed".
+const NOT_COMPUTED = Number.NaN;
+
+function toMinutes(iso: string): number {
+  const d = new Date(iso);
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+function collides(a: Seg, b: Seg): boolean {
+  return a.bottom > b.top && a.top < b.bottom;
+}
+
+// Greedy column assignment: place each seg in the first non-colliding level.
+function buildLevels(segs: Seg[]): Seg[][] {
+  const levels: Seg[][] = [];
+  for (const seg of segs) {
+    let i = 0;
+    while (i < levels.length && levels[i].some((o) => collides(seg, o))) i++;
+    if (!levels[i]) levels[i] = [];
+    levels[i].push(seg);
+    seg.level = i;
+  }
+  return levels;
+}
+
+// For each seg, collect the deeper-level segs that overlap it in time.
+function buildForwardSegs(levels: Seg[][]): void {
+  for (let i = 0; i < levels.length; i++) {
+    for (const seg of levels[i]) {
+      seg.forwardSegs = [];
+      for (let k = i + 1; k < levels.length; k++) {
+        for (const other of levels[k]) {
+          if (collides(seg, other)) seg.forwardSegs.push(other);
+        }
+      }
+    }
+  }
+}
+
+// Longest path length through forwardSegs.
+function computePressure(seg: Seg): void {
+  if (!Number.isNaN(seg.forwardPressure)) return;
+  let max = 0;
+  for (const fwd of seg.forwardSegs) {
+    computePressure(fwd);
+    max = Math.max(max, 1 + fwd.forwardPressure);
+  }
+  seg.forwardPressure = max;
+}
+
+// Recursively compute left/right coords. Consecutive segs with equal pressure
+// form a "series" that splits the freed space evenly.
+function computeCoords(seg: Seg, seriesBackPressure: number, seriesBackCoord: number): void {
+  if (!Number.isNaN(seg.forwardCoord)) return;
+  const { forwardSegs } = seg;
+  if (forwardSegs.length === 0) {
+    seg.forwardCoord = 1;
+  } else {
+    forwardSegs.sort((a, b) => b.forwardPressure - a.forwardPressure);
+    computeCoords(forwardSegs[0], seriesBackPressure + 1, seriesBackCoord);
+    seg.forwardCoord = forwardSegs[0].backwardCoord;
+  }
+  seg.backwardCoord =
+    seg.forwardCoord - (seg.forwardCoord - seriesBackCoord) / (seriesBackPressure + 1);
+  for (const fwd of forwardSegs) computeCoords(fwd, 0, seg.forwardCoord);
+}
+
+export function computeOverlapLayout(events: OverlapEvent[]): Map<string, OverlapLayout> {
+  const result = new Map<string, OverlapLayout>();
+  if (events.length === 0) return result;
+
+  const segs: Seg[] = events
+    .map((e) => ({
+      id: e.id,
+      top: toMinutes(e.start),
+      bottom: toMinutes(e.end),
+      level: 0,
+      forwardSegs: [] as Seg[],
+      forwardPressure: NOT_COMPUTED,
+      backwardCoord: 0,
+      forwardCoord: NOT_COMPUTED,
+    }))
+    .sort((a, b) => a.top - b.top || b.bottom - a.bottom);
+
+  const levels = buildLevels(segs);
+  buildForwardSegs(levels);
+  for (const seg of levels[0] || []) computePressure(seg);
+  for (const seg of levels[0] || []) computeCoords(seg, 0, 0);
+
+  // slotEventOverlap: double each width (clamped to the column edge) so
+  // earlier events span behind later ones. Events reaching full width need
+  // no layout entry.
+  for (const seg of segs) {
+    const width = Math.min(1 - seg.backwardCoord, (seg.forwardCoord - seg.backwardCoord) * 2);
+    if (width < 1) result.set(seg.id, { left: seg.backwardCoord, width, level: seg.level });
+  }
+
+  return result;
+}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -102,8 +102,9 @@ export function DashboardView({
   }, [events, selectedDate]);
 
   // Group the next 7 days of events for the Classic "This Week" column
+  // (starts tomorrow — today is covered by the Today column)
   const weekEvents = useMemo(() => {
-    const start = startOfDay(new Date());
+    const start = addDays(startOfDay(new Date()), 1);
     return Array.from({ length: 7 }, (_, i) => {
       const day = addDays(start, i);
       const dayEvents = events

--- a/src/components/EventBlock.tsx
+++ b/src/components/EventBlock.tsx
@@ -16,6 +16,7 @@ interface EventBlockProps {
 export function EventBlock({ event, onClick, style, allDay, multiDay, draggable, expanded, onDragStart, onDragEnd }: EventBlockProps) {
   const pastel = getPastelColor(event.color);
   const full = getFullColor(event.color);
+  const isPast = parseISO(event.end).getTime() < Date.now();
 
   const timeLabel = event.allDay
     ? 'All day'
@@ -26,7 +27,7 @@ export function EventBlock({ event, onClick, style, allDay, multiDay, draggable,
   if (multiDay) {
     return (
       <div
-        className="event-block-inner event-block-inner--multiday"
+        className={`event-block-inner event-block-inner--multiday ${isPast ? 'event-block--past' : ''}`}
         style={{ backgroundColor: pastel }}
       >
         <div className="event-block-stripe" style={{ backgroundColor: full }} />
@@ -39,7 +40,7 @@ export function EventBlock({ event, onClick, style, allDay, multiDay, draggable,
 
   return (
     <button
-      className={`event-block ${allDay ? 'event-block--allday' : ''} ${draggable ? 'event-block--draggable' : ''} ${expanded ? 'event-block--expanded' : ''}`}
+      className={`event-block ${allDay ? 'event-block--allday' : ''} ${draggable ? 'event-block--draggable' : ''} ${expanded ? 'event-block--expanded' : ''} ${isPast ? 'event-block--past' : ''}`}
       style={{
         ...style,
         backgroundColor: pastel,

--- a/src/components/EventCard.test.tsx
+++ b/src/components/EventCard.test.tsx
@@ -61,4 +61,23 @@ describe('EventCard', () => {
     await user.click(card);
     expect(onClick).toHaveBeenCalledWith(event);
   });
+
+  it('grays out events that have already ended', () => {
+    const { container } = render(<EventCard event={makeEvent()} />);
+    expect(container.querySelector('.event-card')).toHaveClass('event-card--past');
+  });
+
+  it('keeps future-dated events un-grayed even when their clock time is early', () => {
+    const { container } = render(
+      <EventCard event={makeEvent({ start: '2999-01-01T08:00:00', end: '2999-01-01T09:00:00' })} />,
+    );
+    expect(container.querySelector('.event-card')).not.toHaveClass('event-card--past');
+  });
+
+  it('keeps future all-day events un-grayed (bare-date end parsed as a locale date)', () => {
+    const { container } = render(
+      <EventCard event={makeEvent({ allDay: true, start: '2999-01-01', end: '2999-01-02' })} />,
+    );
+    expect(container.querySelector('.event-card')).not.toHaveClass('event-card--past');
+  });
 });

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -9,6 +9,7 @@ interface EventCardProps {
 export function EventCard({ event, onClick }: EventCardProps) {
   const pastel = getPastelColor(event.color);
   const full = getFullColor(event.color);
+  const isPast = parseISO(event.end).getTime() < Date.now();
 
   const timeLabel = event.allDay
     ? 'All day'
@@ -16,7 +17,7 @@ export function EventCard({ event, onClick }: EventCardProps) {
 
   return (
     <div
-      className={`event-card ${onClick ? 'event-card--clickable' : ''}`}
+      className={`event-card ${onClick ? 'event-card--clickable' : ''} ${isPast ? 'event-card--past' : ''}`}
       style={{
         backgroundColor: pastel,
         borderLeft: `4px solid ${full}`,

--- a/src/components/WeekCalendar.tsx
+++ b/src/components/WeekCalendar.tsx
@@ -11,6 +11,7 @@ import {
   getMinutes,
 } from 'date-fns';
 import { CalendarEvent } from '../types';
+import { computeOverlapLayout, type OverlapLayout } from '../utils/overlap-layout';
 import { EventBlock } from './EventBlock';
 import { EventDetailsPopover } from './EventDetailsPopover';
 import { useWeatherForecast } from '../hooks/useWeatherForecast';
@@ -331,67 +332,8 @@ export function WeekCalendar({ events, hiddenCalendars, onEventClick, onSlotClic
 
   const isCurrentWeek = weekOffset === 0;
 
-  // Compute overlap layout for a list of events in one day column.
-  // Returns a map of eventId → { column, totalColumns } for side-by-side rendering.
-  function computeOverlapLayout(dayEvents: CalendarEvent[]): Map<string, { col: number; total: number }> {
-    const result = new Map<string, { col: number; total: number }>();
-    if (dayEvents.length === 0) return result;
-
-    // Sort by start time, then longer events first
-    const sorted = [...dayEvents].sort((a, b) => {
-      const cmp = a.start.localeCompare(b.start);
-      if (cmp !== 0) return cmp;
-      return b.end.localeCompare(a.end);
-    });
-
-    // Groups of overlapping events
-    const groups: CalendarEvent[][] = [];
-    let currentGroup: CalendarEvent[] = [];
-    let currentGroupEnd = '';
-
-    for (const event of sorted) {
-      if (currentGroup.length === 0 || event.start < currentGroupEnd) {
-        currentGroup.push(event);
-        if (event.end > currentGroupEnd) currentGroupEnd = event.end;
-      } else {
-        groups.push(currentGroup);
-        currentGroup = [event];
-        currentGroupEnd = event.end;
-      }
-    }
-    if (currentGroup.length > 0) groups.push(currentGroup);
-
-    // Assign columns within each group
-    for (const group of groups) {
-      const columns: CalendarEvent[][] = [];
-      for (const event of group) {
-        let placed = false;
-        for (let c = 0; c < columns.length; c++) {
-          const lastInCol = columns[c][columns[c].length - 1];
-          if (event.start >= lastInCol.end) {
-            columns[c].push(event);
-            result.set(event.id, { col: c, total: 0 });
-            placed = true;
-            break;
-          }
-        }
-        if (!placed) {
-          columns.push([event]);
-          result.set(event.id, { col: columns.length - 1, total: 0 });
-        }
-      }
-      // Set total columns for the group
-      for (const event of group) {
-        const entry = result.get(event.id);
-        if (entry) entry.total = columns.length;
-      }
-    }
-
-    return result;
-  }
-
   // Calculate position and height for a timed event
-  function getEventStyle(event: CalendarEvent, layout?: { col: number; total: number }): React.CSSProperties {
+  function getEventStyle(event: CalendarEvent, layout?: OverlapLayout): React.CSSProperties {
     const start = parseISO(event.start);
     const end = parseISO(event.end);
     const startHour = getHours(start) + getMinutes(start) / 60;
@@ -409,10 +351,10 @@ export function WeekCalendar({ events, hiddenCalendars, onEventClick, onSlotClic
     };
 
     // Side-by-side columns for overlapping events
-    if (layout && layout.total > 1) {
-      const widthPct = 100 / layout.total;
-      style.left = `calc(${layout.col * widthPct}% + 1px)`;
-      style.width = `calc(${widthPct}% - 2px)`;
+    if (layout && layout.width < 1) {
+      style.left = `calc(${layout.left * 100}% + 1px)`;
+      style.width = `calc(${layout.width * 100}% - 2px)`;
+      style.zIndex = layout.level + 2;
     }
 
     return style;

--- a/src/styles/beacon.css
+++ b/src/styles/beacon.css
@@ -1042,6 +1042,12 @@ a:focus:not(:focus-visible) {
   transform: scale(0.99);
 }
 
+/* Events that have already ended are muted so upcoming ones stand out */
+.event-block--past {
+  opacity: 0.55;
+  filter: grayscale(0.6);
+}
+
 .event-block-stripe {
   width: 3px;
   flex-shrink: 0;

--- a/src/styles/beacon.css
+++ b/src/styles/beacon.css
@@ -1027,7 +1027,7 @@ a:focus:not(:focus-visible) {
   z-index: 1;
   display: flex;
   min-height: 22px;
-  border: none;
+  border: 1px solid #fff;
   text-align: left;
   padding: 0;
 }
@@ -1060,9 +1060,11 @@ a:focus:not(:focus-visible) {
   font-size: 0.75rem;
   font-weight: 600;
   color: rgba(0, 0, 0, 0.85);
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
+  overflow-wrap: break-word;
   line-height: 1.3;
 }
 

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -457,6 +457,12 @@
   cursor: pointer;
 }
 
+/* Events that have already ended are muted so upcoming ones stand out */
+.event-card--past {
+  opacity: 0.6;
+  filter: grayscale(0.6);
+}
+
 .event-card-calendar {
   font-size: 11px;
   font-weight: 600;

--- a/src/utils/overlap-layout.test.ts
+++ b/src/utils/overlap-layout.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { computeOverlapLayout, type OverlapEvent } from './overlap-layout';
+
+const d = (time: string) => `2026-09-08T${time}:00`;
+
+function ev(id: string, start: string, end: string): OverlapEvent {
+  return { id, start: d(start), end: d(end) };
+}
+
+describe('computeOverlapLayout', () => {
+  it('returns an empty map when there are no events', () => {
+    expect(computeOverlapLayout([]).size).toBe(0);
+  });
+
+  it('emits no layout for non-overlapping events', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '10:00'),
+      ev('b', '10:00', '11:00'),
+      ev('c', '13:00', '14:00'),
+    ]);
+    expect(layout.size).toBe(0);
+  });
+
+  it('spans the first of two overlaps full-width behind the second', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '11:00'),
+      ev('b', '10:00', '12:00'),
+    ]);
+    // a doubles to full width → omitted (CSS default already means full width)
+    expect(layout.get('a')).toBeUndefined();
+    // b doubles onto the right half
+    expect(layout.get('b')!.left).toBeCloseTo(0.5);
+    expect(layout.get('b')!.width).toBeCloseTo(0.5);
+    expect(layout.get('b')!.level).toBe(1);
+  });
+
+  it('extends the first two of three overlapping events behind', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '11:00'),
+      ev('b', '09:30', '10:30'),
+      ev('c', '10:00', '11:00'),
+    ]);
+    // raw thirds a(0,1/3) b(1/3,2/3) c(2/3,1); doubled → a,b 2/3, c 1/3
+    expect(layout.get('a')!.left).toBeCloseTo(0);
+    expect(layout.get('a')!.width).toBeCloseTo(2 / 3);
+    expect(layout.get('b')!.left).toBeCloseTo(1 / 3);
+    expect(layout.get('b')!.width).toBeCloseTo(2 / 3);
+    expect(layout.get('c')!.left).toBeCloseTo(2 / 3);
+    expect(layout.get('c')!.width).toBeCloseTo(1 / 3);
+  });
+
+  it('lets a long event span full width while two short events sit right', () => {
+    const layout = computeOverlapLayout([
+      ev('long', '09:00', '17:00'),
+      ev('s1', '10:00', '11:00'),
+      ev('s2', '12:00', '13:00'),
+    ]);
+    expect(layout.get('long')).toBeUndefined();
+    expect(layout.get('s1')!.left).toBeCloseTo(0.5);
+    expect(layout.get('s1')!.width).toBeCloseTo(0.5);
+    expect(layout.get('s2')!.left).toBeCloseTo(0.5);
+    expect(layout.get('s2')!.width).toBeCloseTo(0.5);
+  });
+
+  it('keeps a low-competition event wider than the cluster it joins', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '17:00'),
+      ev('b', '10:00', '12:00'),
+      ev('c', '11:00', '13:00'),
+      ev('d', '14:00', '15:00'),
+    ]);
+    // d only overlaps a, so it spans the two right columns
+    expect(layout.get('a')!.left).toBeCloseTo(0);
+    expect(layout.get('b')!.left).toBeCloseTo(1 / 3);
+    expect(layout.get('c')!.left).toBeCloseTo(2 / 3);
+    expect(layout.get('d')!.left).toBeCloseTo(1 / 3);
+    expect(layout.get('d')!.width).toBeCloseTo(2 / 3);
+  });
+
+  it('keeps all layout fractions within the day column', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '18:00'),
+      ev('b', '09:30', '10:30'),
+      ev('c', '10:00', '12:00'),
+      ev('d', '11:30', '13:00'),
+      ev('e', '12:30', '14:30'),
+      ev('f', '14:00', '16:00'),
+    ]);
+    for (const [id, l] of layout) {
+      expect(l.left, id).toBeGreaterThanOrEqual(0);
+      expect(l.width, id).toBeGreaterThan(0);
+      expect(l.left + l.width, id).toBeLessThanOrEqual(1 + 1e-9);
+    }
+  });
+
+  it('assigns increasing levels for stacked columns', () => {
+    const layout = computeOverlapLayout([
+      ev('a', '09:00', '12:00'),
+      ev('b', '09:30', '11:30'),
+      ev('c', '10:00', '11:00'),
+    ]);
+    const levels = [layout.get('a')!.level, layout.get('b')!.level, layout.get('c')!.level];
+    expect(levels).toEqual([0, 1, 2]);
+  });
+});

--- a/src/utils/overlap-layout.ts
+++ b/src/utils/overlap-layout.ts
@@ -1,0 +1,132 @@
+/**
+ * Side-by-side layout for timed events sharing one day column.
+ * Port of FullCalendar v4 TimeGridEventRenderer's overlap algorithm
+ * (matches Google Calendar's visual style).
+ */
+
+export interface OverlapEvent {
+  id: string;
+  /** ISO 8601 datetime — lexicographic order matches chronological order */
+  start: string;
+  end: string;
+}
+
+export interface OverlapLayout {
+  /** Left edge as a 0–1 fraction of the day column width */
+  left: number;
+  /** Width as a 0–1 fraction of the day column width */
+  width: number;
+  /** Column level (0-based); higher = drawn on top */
+  level: number;
+}
+
+interface Seg {
+  id: string;
+  top: number; // minutes from midnight
+  bottom: number; // minutes from midnight
+  level: number;
+  forwardSegs: Seg[]; // segs in deeper levels that overlap this one
+  forwardPressure: number; // memoised longest forward-chain depth
+  backwardCoord: number; // left edge 0–1
+  forwardCoord: number; // right edge 0–1
+}
+
+// Coords are always 0–1, so NaN marks "not yet computed".
+const NOT_COMPUTED = Number.NaN;
+
+function toMinutes(iso: string): number {
+  const d = new Date(iso);
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+function collides(a: Seg, b: Seg): boolean {
+  return a.bottom > b.top && a.top < b.bottom;
+}
+
+// Greedy column assignment: place each seg in the first non-colliding level.
+function buildLevels(segs: Seg[]): Seg[][] {
+  const levels: Seg[][] = [];
+  for (const seg of segs) {
+    let i = 0;
+    while (i < levels.length && levels[i].some((o) => collides(seg, o))) i++;
+    if (!levels[i]) levels[i] = [];
+    levels[i].push(seg);
+    seg.level = i;
+  }
+  return levels;
+}
+
+// For each seg, collect the deeper-level segs that overlap it in time.
+function buildForwardSegs(levels: Seg[][]): void {
+  for (let i = 0; i < levels.length; i++) {
+    for (const seg of levels[i]) {
+      seg.forwardSegs = [];
+      for (let k = i + 1; k < levels.length; k++) {
+        for (const other of levels[k]) {
+          if (collides(seg, other)) seg.forwardSegs.push(other);
+        }
+      }
+    }
+  }
+}
+
+// Longest path length through forwardSegs.
+function computePressure(seg: Seg): void {
+  if (!Number.isNaN(seg.forwardPressure)) return;
+  let max = 0;
+  for (const fwd of seg.forwardSegs) {
+    computePressure(fwd);
+    max = Math.max(max, 1 + fwd.forwardPressure);
+  }
+  seg.forwardPressure = max;
+}
+
+// Recursively compute left/right coords. Consecutive segs with equal pressure
+// form a "series" that splits the freed space evenly.
+function computeCoords(seg: Seg, seriesBackPressure: number, seriesBackCoord: number): void {
+  if (!Number.isNaN(seg.forwardCoord)) return;
+  const { forwardSegs } = seg;
+  if (forwardSegs.length === 0) {
+    seg.forwardCoord = 1;
+  } else {
+    forwardSegs.sort((a, b) => b.forwardPressure - a.forwardPressure);
+    computeCoords(forwardSegs[0], seriesBackPressure + 1, seriesBackCoord);
+    seg.forwardCoord = forwardSegs[0].backwardCoord;
+  }
+  seg.backwardCoord =
+    seg.forwardCoord - (seg.forwardCoord - seriesBackCoord) / (seriesBackPressure + 1);
+  for (const fwd of forwardSegs) computeCoords(fwd, 0, seg.forwardCoord);
+}
+
+export function computeOverlapLayout(events: OverlapEvent[]): Map<string, OverlapLayout> {
+  const result = new Map<string, OverlapLayout>();
+  if (events.length === 0) return result;
+
+  const segs: Seg[] = events
+    .map((e) => ({
+      id: e.id,
+      top: toMinutes(e.start),
+      bottom: toMinutes(e.end),
+      level: 0,
+      forwardSegs: [] as Seg[],
+      forwardPressure: NOT_COMPUTED,
+      backwardCoord: 0,
+      forwardCoord: NOT_COMPUTED,
+    }))
+    .sort((a, b) => a.top - b.top || b.bottom - a.bottom);
+
+  const levels = buildLevels(segs);
+  buildForwardSegs(levels);
+  for (const seg of levels[0] || []) computePressure(seg);
+  for (const seg of levels[0] || []) computeCoords(seg, 0, 0);
+
+  // slotEventOverlap: double each width (clamped to the column edge) so
+  // earlier events span behind later ones. Events reaching full width need
+  // no layout entry.
+  for (const seg of segs) {
+    const width = Math.min(1 - seg.backwardCoord, (seg.forwardCoord - seg.backwardCoord) * 2);
+    if (width < 1) result.set(seg.id, { left: seg.backwardCoord, width, level: seg.level });
+  }
+
+  return result;
+}


### PR DESCRIPTION
This is ported from FullCalendar slot event overlap algorithm so that earlier
events spans behind later ones. This also increases the width of the events so
that the texts can be read easily.

A white border is introduced around the event so that overlapping events can be
easily distinguished. this also gives consecutive events a slight border so
that they don't blend into each other.

- This also grays out past events on the dashboard so it's easier to visually inspect.
- In the classic view, the week column also excludes today because it's redundant.

Calendar view showing overlap:
<img width="269" height="309" alt="Screenshot 2026-09-10 at 9 04 04 PM" src="https://github.com/user-attachments/assets/ed79033b-910a-4dca-9cb8-f6f3542a5187" />

Dashboard view with expired/future event:
<img width="659" height="246" alt="Screenshot 2026-09-10 at 9 23 56 PM" src="https://github.com/user-attachments/assets/483e3025-b023-4800-86f7-6c19ac0fbe51" />
